### PR TITLE
scrape metadata in responses with entities list

### DIFF
--- a/configs/vm.yaml
+++ b/configs/vm.yaml
@@ -8,3 +8,5 @@
   help: Power state of the VM.
 - name: vcpu_reservation_hz
   help: vCPU reservation in Hz.
+- name: grand_total_entities
+  help: Total number of VMs.


### PR DESCRIPTION
# Metadata Scraping

## Description

Adds the ability to collect metrics from the metadata section of responses that contain a list of entities for things like entity count.
