### PR TITLE
Feature: Add PC APIv3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ PC_CLUSTER_URL=https://your-pc-cluster.yourdomain.com:9440
 PE_TASK_ACCOUNT=PETaskAccount
 PC_TASK_ACCOUNT=PCTaskAccount
 CLUSTER_PREFIX=optional-cluster-prefix to filter cluster names
+PC_API_VERSION=v4 (Optional, defaults to v3)
 ```
 
 ## Deployment

--- a/internal/nutanix/nutanix.go
+++ b/internal/nutanix/nutanix.go
@@ -181,6 +181,9 @@ func (c *PEClient) CreateRequest(ctx context.Context, reqType, action string, p 
 			return nil, fmt.Errorf("failed to marshal payload: %w", err)
 		}
 		req, err = http.NewRequestWithContext(ctx, reqType, fullURL, strings.NewReader(string(jsonPayload)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
 		req.Header.Set("Content-Type", "application/json")
 	} else {
 		// Use the old method with body as string if no payload is provided


### PR DESCRIPTION
# Fetch PE clusters using APIv3 for versions of PC prior to 2024.1

## Description

Added optional env var PC_API_VERSION to specify using v3 or v4, defaults to v4.

## Types of Changes

- New feature: PC 2023/apiv3  support
- Configuration change: Add PC_API_VERSION env var
- Refactor/improvements: Nutanix module now supports sending payload in requests

