### PR TITLE
Feat: Export Boolean values

### DIFF
--- a/internal/prom/exporter.go
+++ b/internal/prom/exporter.go
@@ -61,6 +61,12 @@ func (e *Exporter) valueToFloat64(value interface{}) float64 {
 	switch v := value.(type) {
 	case float64:
 		return v
+	case bool:
+		if v == true {
+			return 1.0
+		} else {
+			return 0.0
+		}
 	case string:
 		if v == "on" {
 			return 1.0


### PR DESCRIPTION
# Export boolean values

## Description

This change allows boolean values to be exported and collected by Prometheus.

For example (if set in the configuration):

cluster:

* is_degraded

vm:

* boot_uefi_boot
* boot_secure_boot

## Types of Changes

- New feature: Export boolean values