### PR TITLE
Fix: Skip if value is nil

### DIFF
--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -166,7 +166,7 @@ func FetchClusters(prismClient *nutanix.Cluster, version string) (map[string]str
 				continue
 			}
 			network, networkOk := clusterMap["network"].(map[string]interface{})["externalAddress"].(map[string]interface{})
-			if !networkOk {
+			if !networkOk || network["ipv4"] == nil {
 				continue
 			}
 			ip, ipOk := network["ipv4"].(map[string]interface{})["value"].(string)


### PR DESCRIPTION
# Check the next entry if value is nil

## Description

Hash from http://pc:9440/api/clustermgmt/v4.0.b1/config/clusters

We encountered a case where the array in `{ data: [] }` contains multiple objects, but in one of them, the `network["ipv4"]` was missing/`nil`, preventing the exporter from starting.

This hash is ok and works:

```
[...]
        "externalAddress": {
              "$reserved": {
                    "$fv": "v1.r0"
              },
              "$objectType": "common.v1.config.IPAddress",
              "ipv4": {
                    "$reserved": {
                          "$fv": "v1.r0"
                    },
                    "$objectType": "common.v1.config.IPv4Address",
                    "value": "[...]",
                    "prefixLength": 32
              }

        },
[...]
```

And this is the second, non working hash:
```
[...]
        "externalAddress": {

              "$reserved": {
                    "$fv": "v1.r0"
              },
              "$objectType": "common.v1.config.IPAddress"

        },
[...]
```

This may be related to the latest Nutanix Prism Central version, but I am not sure.

## Types of Changes

What types of changes does your code introduce? Keep the ones that apply:

- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements