### PR TITLE
Add environment variable credential provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The Nutanix Exporter is a Go application that fetches live data from any number 
   - The `VAULT_ADDR` environment variable must not be defined
   - `PC_USERNAME` and `PC_PASSWORD` environment variables must be defined with Prism Central credentials
   - For each cluster the `PE_USERNAME_<CLUSTERNAME>` and `PE_PASSWORD_<CLUSTERNAME>` environment variables have to be defined with Prism Element credentials
+  - The cluster specific environment variable names can only contain letters A-Z, numbers 0-9 and underscores (_).
+    Lower case letters should be converted to upper case and all other characters to underscores.
 
 ### Metrics Configuration
 
@@ -80,44 +82,32 @@ To build and run in a container:
 3. `docker run -p 9408:9408 --env-file configs/exporter.env nutanix_exporter`
 4. The exporter will now be running on `localhost:9408`
 
-Example exporter.env for using HashiCorp Vault as the credential provider:
+Example exporter.env:
 
 ```yaml
+### Common options
+PC_CLUSTER_NAME=your-pc-cluster-name
+PC_CLUSTER_URL=https://your-pc-cluster.yourdomain.com:9440
+PC_API_VERSION=v3 (Optional, defaults to v4. Supports v3, v4b1, v4)
+CLUSTER_REFRESH_INTERVAL=1800 (Seconds. Optional, defaults to 0, i.e. no refreshing)
+CLUSTER_PREFIX=optional-cluster-prefix to filter cluster names
+
+### For HashiCorp Vault only
 VAULT_ADDR=https://your-vault-server.yourdomain.com
 VAULT_NAMESPACE=production
 VAULT_ENGINE_NAME=NutanixKV2
 VAULT_ROLE_ID=12345678-1234-5678-1234-567812345678
 VAULT_SECRET_ID=12345678-1234-5678-1234-567812345678
-PC_CLUSTER_NAME=your-pc-cluster-name
-PC_CLUSTER_URL=https://your-pc-cluster.yourdomain.com:9440
-PE_TASK_ACCOUNT=PETaskAccount
-PC_TASK_ACCOUNT=PCTaskAccount
-CLUSTER_REFRESH_INTERVAL=1800 (Seconds. Optional, defaults to 0, i.e. no refreshing)
 VAULT_REFRESH_INTERVAL=1500 (Seconds. Optional, defaults to 0, i.e. no refreshing)
-CLUSTER_PREFIX=optional-cluster-prefix to filter cluster names
-PC_API_VERSION=v3 (Optional, defaults to v4. Supports v3, v4b1, v4)
-```
-
-Example exporter.env for using environment variables as the credential provider:
-
-```yaml
-PC_CLUSTER_NAME=your-pc-cluster-name
-PC_CLUSTER_URL=https://your-pc-cluster.yourdomain.com:9440
 PE_TASK_ACCOUNT=PETaskAccount
 PC_TASK_ACCOUNT=PCTaskAccount
-PC_USERNAME=prism-central-user
-PC_PASSWORD=pc-user-password
+
+### For environment variable credential provider only
 PE_USERNAME_<CLUSTERNAME_ONE>=cluster1-user-name
 PE_PASSWORD_<CLUSTERNAME_ONE>=cluster1-user-password
 PE_USERNAME_<CLUSTERNAME_TWO_>=cluster2-user-name
 PE_PASSWORD_<CLUSTERNAME_TWO>=cluster2-user-password
-CLUSTER_REFRESH_INTERVAL=1800 (Seconds. Optional, defaults to 0, i.e. no refreshing)
-VAULT_REFRESH_INTERVAL=1500 (Seconds. Optional, defaults to 0, i.e. no refreshing)
-CLUSTER_PREFIX=optional-cluster-prefix to filter cluster names
-PC_API_VERSION=v3 (Optional, defaults to v4. Supports v3, v4b1, v4)
 ```
-
-The VAULT_ADDR environment variable must not be defined when using the environment variable credential provider as defining it tells the exporter to use the HashiCorp Vault instead.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 ## About
 
-The Nutanix Exporter is a Go application that fetches live data from any number of Prism Element servers and presents it in a format ingestable by Prometheus. It runs as a docker container, automatically fetching all PE clusters from a Prism Central instance and exporting metrics from multiple APIv2 endpoints (VMs, Hosts, Clusters, etc.).
+The Nutanix Exporter is a Go application that fetches live data from any number of Prism Element servers and presents it in a format ingestible by Prometheus. It runs as a docker container, automatically fetching all PE clusters from a Prism Central instance and exporting metrics from multiple APIv2 endpoints (VMs, Hosts, Clusters, etc.).
 
 ## Features
 
 - YAML config files define which metrics to collect
 - Hashicorp Vault support for fetching cluster credentials
 - Refreshes credentials from Vault on 4xx errors
+- Support for reading cluster credentials from environment variables
 - Parent Exporter class that can be extended for any APIv2 endpoint
 - Per cluster metrics exposed at `/metrics/cluster-name`
 - Optional filtering by cluster name prefix
@@ -17,12 +18,16 @@ The Nutanix Exporter is a Go application that fetches live data from any number 
 
 ### Prerequisites
 
-- Hashicorp Vault server with KVv2 Secrets Engine enabled
+- Nutanix Prism Central 2023.4 or later
+- When using HashiCorp Vault: A Vault server with KVv2 Secrets Engine enabled
   - Secrets Engine name: defined in `VAULT_ENGINE_NAME` environment variable
   - Secret name: defined in `PE_TASK_ACCOUNT` and `PC_TASK_ACCOUNT` environment variables
   - Namespace: Optional, but can be defined in `VAULT_NAMESPACE` environment variable
   - Fields: username, secret
-- Nutanix Prism Central 2023.4 or later
+- When using environment variables for providing the credentials:
+  - The `VAULT_ADDR` environment variable must not be defined
+  - `PC_USERNAME` and `PC_PASSWORD` environment variables must be defined with Prism Central credentials
+  - For each cluster the `PE_USERNAME_<CLUSTERNAME>` and `PE_PASSWORD_<CLUSTERNAME>` environment variables have to be defined with Prism Element credentials
 
 ### Metrics Configuration
 
@@ -75,7 +80,7 @@ To build and run in a container:
 3. `docker run -p 9408:9408 --env-file configs/exporter.env nutanix_exporter`
 4. The exporter will now be running on `localhost:9408`
 
-Example exporter.env:
+Example exporter.env for using HashiCorp Vault as the credential provider:
 
 ```yaml
 VAULT_ADDR=https://your-vault-server.yourdomain.com
@@ -91,8 +96,28 @@ CLUSTER_REFRESH_INTERVAL=1800 (Seconds. Optional, defaults to 0, i.e. no refresh
 VAULT_REFRESH_INTERVAL=1500 (Seconds. Optional, defaults to 0, i.e. no refreshing)
 CLUSTER_PREFIX=optional-cluster-prefix to filter cluster names
 PC_API_VERSION=v3 (Optional, defaults to v4. Supports v3, v4b1, v4)
-
 ```
+
+Example exporter.env for using environment variables as the credential provider:
+
+```yaml
+PC_CLUSTER_NAME=your-pc-cluster-name
+PC_CLUSTER_URL=https://your-pc-cluster.yourdomain.com:9440
+PE_TASK_ACCOUNT=PETaskAccount
+PC_TASK_ACCOUNT=PCTaskAccount
+PC_USERNAME=prism-central-user
+PC_PASSWORD=pc-user-password
+PE_USERNAME_<CLUSTERNAME_ONE>=cluster1-user-name
+PE_PASSWORD_<CLUSTERNAME_ONE>=cluster1-user-password
+PE_USERNAME_<CLUSTERNAME_TWO_>=cluster2-user-name
+PE_PASSWORD_<CLUSTERNAME_TWO>=cluster2-user-password
+CLUSTER_REFRESH_INTERVAL=1800 (Seconds. Optional, defaults to 0, i.e. no refreshing)
+VAULT_REFRESH_INTERVAL=1500 (Seconds. Optional, defaults to 0, i.e. no refreshing)
+CLUSTER_PREFIX=optional-cluster-prefix to filter cluster names
+PC_API_VERSION=v3 (Optional, defaults to v4. Supports v3, v4b1, v4)
+```
+
+The VAULT_ADDR environment variable must not be defined when using the environment variable credential provider as defining it tells the exporter to use the HashiCorp Vault instead.
 
 ## Deployment
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2024 Ingka Holding B.V. All Rights Reserved.
+Licensed under the GPL, Version 2 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       <https://www.gnu.org/licenses/gpl-2.0.en.html>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package auth handles retrieving the correct credentials for authenticating with
+// Prism Central and Prism Element clusters.
+//
+// Supported credential providers are:
+// - HashiCorp Vault
+// - Environment variables
+
+package auth
+
+import (
+	"log"
+	"os"
+)
+
+// CredentialProvider defines which functions a credential provider for Nutanix
+// cluster authentication has to implement.
+type CredentialProvider interface {
+	GetPCCreds(cluster string) (string, string, error)
+	GetPECreds(cluster string) (string, string, error)
+}
+
+// getEnvOrFatal returns the value of the specified environment variable or exits the program.
+func getEnvOrFatal(envVar string) string {
+	value := os.Getenv(envVar)
+	if value == "" {
+		log.Fatalf("%s environment variable is not set", envVar)
+	}
+	return value
+}

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -22,16 +22,16 @@ import (
 	"strings"
 )
 
-// EnvVarCredentialProvider implements the methods for getting Nutanix
+// EnvCredentialProvider implements the methods for getting Nutanix
 // cluster authentication credentials from environment variables.
-type EnvVarCredentialProvider struct{}
+type EnvCredentialProvider struct{}
 
 // ConvertClusterName changes any characters that should not be used in
 // environment variables to an underscore (_).
 func ConvertClusterName(cluster string) string {
 	cluster = strings.ToUpper(cluster)
 
-	r, _ := regexp.Compile("[^A-Z_0-9]+") // [^A-Za-z_0-9]+ global /g
+	r, _ := regexp.Compile("[^A-Z_0-9]+")
 	cluster = r.ReplaceAllString(cluster, "_")
 
 	return cluster
@@ -74,13 +74,13 @@ func getCreds(cluster string, isPC bool) (string, string, error) {
 }
 
 // GetPCCreds returns the username and password for the specified Prism Central cluster
-func (evCP *EnvVarCredentialProvider) GetPCCreds(cluster string) (string, string, error) {
+func (evCP *EnvCredentialProvider) GetPCCreds(cluster string) (string, string, error) {
 
 	return getCreds(cluster, true)
 }
 
 // GetPECreds returns the username and password for the specified Prism Element cluster
-func (evCP *EnvVarCredentialProvider) GetPECreds(cluster string) (string, string, error) {
+func (evCP *EnvCredentialProvider) GetPECreds(cluster string) (string, string, error) {
 
 	return getCreds(cluster, false)
 }

--- a/internal/auth/environment.go
+++ b/internal/auth/environment.go
@@ -1,0 +1,86 @@
+/*
+Copyright © 2024 Ingka Holding B.V. All Rights Reserved.
+Licensed under the GPL, Version 2 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       <https://www.gnu.org/licenses/gpl-2.0.en.html>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"errors"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// EnvVarCredentialProvider implements the methods for getting Nutanix
+// cluster authentication credentials from environment variables.
+type EnvVarCredentialProvider struct{}
+
+// ConvertClusterName changes any characters that should not be used in
+// environment variables to an underscore (_).
+func ConvertClusterName(cluster string) string {
+	cluster = strings.ToUpper(cluster)
+
+	r, _ := regexp.Compile("[^A-Z_0-9]+") // [^A-Za-z_0-9]+ global /g
+	cluster = r.ReplaceAllString(cluster, "_")
+
+	return cluster
+}
+
+// getEnvVarsForCluster generates the names for the environment variables
+// that have to be used for providing login credentials of a Nutanix cluster.
+func getEnvVarsForCluster(cluster string, isPC bool) (string, string) {
+	var evU, evP string
+
+	if isPC {
+		evU = "PC_USERNAME"
+		evP = "PC_PASSWORD"
+	} else {
+		evU = "PE_USERNAME_" + ConvertClusterName(cluster)
+		evP = "PE_PASSWORD_" + ConvertClusterName(cluster)
+	}
+
+	return evU, evP
+}
+
+// getCreds reads the appropriate environment variables and returns the username and password
+// for the provided cluster name.
+//
+// If isPC is true the credentials for Prism Central will be returned, otherwise those for Prism Element.
+func getCreds(cluster string, isPC bool) (string, string, error) {
+	evU, evP := getEnvVarsForCluster(cluster, isPC)
+
+	username := os.Getenv(evU)
+	if username == "" {
+		return "", "", errors.New("environment variable " + evU + " not set for cluster " + cluster)
+	}
+
+	password := os.Getenv(evP)
+	if password == "" {
+		return "", "", errors.New("environment variable " + evP + " not set for cluster " + cluster)
+	}
+
+	return username, password, nil
+}
+
+// GetPCCreds returns the username and password for the specified Prism Central cluster
+func (evCP *EnvVarCredentialProvider) GetPCCreds(cluster string) (string, string, error) {
+
+	return getCreds(cluster, true)
+}
+
+// GetPECreds returns the username and password for the specified Prism Element cluster
+func (evCP *EnvVarCredentialProvider) GetPECreds(cluster string) (string, string, error) {
+
+	return getCreds(cluster, false)
+}

--- a/internal/auth/vault.go
+++ b/internal/auth/vault.go
@@ -42,15 +42,6 @@ type VaultClient struct {
 	client *vault.Client
 }
 
-// getEnvOrFatal returns the value of the specified environment variable or exits the program
-func getEnvOrFatal(envVar string) string {
-	value := os.Getenv(envVar)
-	if value == "" {
-		log.Fatalf("%s environment variable is not set", envVar)
-	}
-	return value
-}
-
 // NewVaultClient creates a new Vault client and authenticates using AppRole
 // Uses the VAULT_ADDR, VAULT_ROLE_ID, VAULT_SECRET_ID and VAULT_NAMESPACE environment variables
 func NewVaultClient() (*VaultClient, error) {
@@ -167,4 +158,3 @@ func (v *VaultClient) GetCreds(cluster, path, engine string) (string, string, er
 	}
 	return vaultSecret.Username, vaultSecret.Secret, nil
 }
-

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -99,7 +99,7 @@ func Init() {
 			}()
 		}
 	} else if os.Getenv("PC_USERNAME") != "" {
-		ntnxCredentialProvider = &auth.EnvVarCredentialProvider{}
+		ntnxCredentialProvider = &auth.EnvCredentialProvider{}
 	} else {
 		log.Fatal("No valid credential provider specified")
 	}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -99,6 +99,7 @@ func Init() {
 			}()
 		}
 	} else if os.Getenv("PC_USERNAME") != "" {
+		log.Print("Using the environment variable credential provider")
 		ntnxCredentialProvider = &auth.EnvCredentialProvider{}
 	} else {
 		log.Fatal("No valid credential provider specified")

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -40,11 +40,11 @@ const (
 )
 
 var (
-	ClusterPrefix string
-	PCApiVersion  string
-	VaultClient   *auth.VaultClient
-	ClustersMap   map[string]*nutanix.Cluster
-	clustersMu    sync.RWMutex // Protects ClustersMap
+	ClusterPrefix          string
+	PCApiVersion           string
+	ntnxCredentialProvider auth.CredentialProvider
+	ClustersMap            map[string]*nutanix.Cluster
+	clustersMu             sync.RWMutex // Protects ClustersMap
 )
 
 func Init() {
@@ -74,37 +74,45 @@ func Init() {
 		}
 	}
 
-	log.Printf("Initializing Vault client")
-	vaultClient, err := auth.NewVaultClient()
-	if err != nil {
-		log.Fatalf("Failed to create Vault client: %v", err)
-	}
+	if os.Getenv("VAULT_ADDR") != "" {
+		var err error
 
-	// Periodic refresh of vault client
-	if vaultRefreshInterval > 0 {
-		go func() {
-			ticker := time.NewTicker(time.Duration(vaultRefreshInterval) * time.Second)
-			defer ticker.Stop()
+		log.Printf("Initializing Vault client")
+		ntnxCredentialProvider, err = auth.NewVaultClient()
+		if err != nil {
+			log.Fatalf("Failed to create Vault client: %v", err)
+		}
 
-			for range ticker.C {
-				log.Printf("Refreshing Vault client...")
-				vaultClient, err = auth.NewVaultClient()
-				if err != nil {
-					log.Fatalf("Failed to refresh Vault client: %v", err)
+		// Periodic refresh of vault client
+		if vaultRefreshInterval > 0 {
+			go func() {
+				ticker := time.NewTicker(time.Duration(vaultRefreshInterval) * time.Second)
+				defer ticker.Stop()
+
+				for range ticker.C {
+					log.Printf("Refreshing Vault client...")
+					ntnxCredentialProvider, err = auth.NewVaultClient()
+					if err != nil {
+						log.Fatalf("Failed to refresh Vault client: %v", err)
+					}
 				}
-			}
-		}()
+			}()
+		}
+	} else if os.Getenv("PC_USERNAME") != "" {
+		ntnxCredentialProvider = &auth.EnvVarCredentialProvider{}
+	} else {
+		log.Fatal("No valid credential provider specified")
 	}
 
 	log.Printf("Connecting to Prism Central")
-	PCCluster := nutanix.NewCluster(PCClusterName, PCClusterURL, vaultClient, true, true, 10*time.Second)
+	PCCluster := nutanix.NewCluster(PCClusterName, PCClusterURL, ntnxCredentialProvider, true, true, 10*time.Second)
 	if PCCluster == nil {
 		log.Fatalf("Failed to connect to Prism Central cluster")
 	}
 
 	// Initial setup of cluster list
 	log.Printf("Initializing clusters")
-	clusterMap, err := SetupClusters(PCCluster, vaultClient, PCApiVersion)
+	clusterMap, err := SetupClusters(PCCluster, ntnxCredentialProvider, PCApiVersion)
 	if err != nil {
 		log.Fatalf("Failed to initialize clusters: %v", err)
 	}
@@ -119,7 +127,7 @@ func Init() {
 			defer ticker.Stop()
 			for range ticker.C { // Every time the ticker ticks, i.e. every refreshInterval secs, exec code below
 				log.Printf("Refreshing cluster list...")
-				newMap, err := SetupClusters(PCCluster, vaultClient, PCApiVersion)
+				newMap, err := SetupClusters(PCCluster, ntnxCredentialProvider, PCApiVersion)
 				if err != nil {
 					log.Printf("Cluster refresh failed: %v", err)
 					continue // wait for next tick and try again
@@ -145,7 +153,7 @@ func Init() {
 			http.NotFound(w, r)
 			return
 		}
-		createClusterMetricsHandler(cluster, vaultClient)(w, r) // produce handler function for the incoming http request and execute it immediately
+		createClusterMetricsHandler(cluster, ntnxCredentialProvider)(w, r) // produce handler function for the incoming http request and execute it immediately
 	})
 
 	log.Printf("Starting Server on %s", ListenAddress)
@@ -155,7 +163,7 @@ func Init() {
 }
 
 // SetupClusters creates Prometheus collectors for every cluster registered in Prism Central
-func SetupClusters(prismClient *nutanix.Cluster, vaultClient *auth.VaultClient, PCApiVersion string) (map[string]*nutanix.Cluster, error) {
+func SetupClusters(prismClient *nutanix.Cluster, ntnxCredentialProvider auth.CredentialProvider, PCApiVersion string) (map[string]*nutanix.Cluster, error) {
 	clusterData, err := FetchClusters(prismClient, PCApiVersion)
 	if err != nil {
 		return nil, err // Propagate the error up
@@ -163,7 +171,7 @@ func SetupClusters(prismClient *nutanix.Cluster, vaultClient *auth.VaultClient, 
 
 	clustersMap := make(map[string]*nutanix.Cluster)
 	for name, url := range clusterData {
-		cluster := nutanix.NewCluster(name, url, vaultClient, false, true, 10*time.Second)
+		cluster := nutanix.NewCluster(name, url, ntnxCredentialProvider, false, true, 10*time.Second)
 		if cluster == nil {
 			log.Printf("Failed to initialize cluster %s", name)
 			continue
@@ -346,10 +354,10 @@ func FetchClusters(prismClient *nutanix.Cluster, version string) (map[string]str
 }
 
 // createClusterMetricsHandler returns a http.HandlerFunc that serves metrics for a specific cluster
-func createClusterMetricsHandler(cluster *nutanix.Cluster, vaultClient *auth.VaultClient) http.HandlerFunc {
+func createClusterMetricsHandler(cluster *nutanix.Cluster, ntnxCredentialProvider auth.CredentialProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Refresh credentials for the specific cluster
-		cluster.RefreshCredentialsIfNeeded(vaultClient)
+		cluster.RefreshCredentialsIfNeeded(ntnxCredentialProvider)
 
 		// Serve metrics from the specific cluster's registry
 		promhttp.HandlerFor(cluster.Registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)


### PR DESCRIPTION
# One-line summary

Provide cluster credentials to the exporter by using environment variables.

## Description

Not all users of the exporter might have a HashiCorp Valt already set up and don't want to do the administrative work of running an instance just for use with the exporter.

This new feature adds the possibility to use environment variables for providing the login credentials to Nutanix Prism Central and clusters instead of using a Vault. It's especially easy to do when using Docker to run the exporter.

A disadvantage of storing passwords as plain text in env-files or in environment variable is that it's much less secure compared to using the Vault. That's why the Vault is still a great and secure option for storing the credentials.

## Types of Changes

- New feature: Provide cluster authentication credentials by using environment variables
- Configuration changes: Add support for environment variables `PC_USERNAME`, `PC_PASSWORD`, `PE_USERNAME_<CLUSTERNAME>` and `PE_PASSWORD_<CLUSTERNAME>`.
- Refactor / improvements:
  - Add an interface for credential providers (additional CPs can be developed).
  - Changes to variable names and function parameters to reflect to use of the new interface.

## Deployment Notes

If no changes are made to the current configuration, the Vault will be used just like before. To make use of the ENV credentials, the variable VAULT_ADDR has to be removed and the appropriate variables add to the configuration. A configuration example can be found in the README.md file.
