### PR TITLE
feat: Make config path configurable via ENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ PC_CLUSTER_URL=https://your-pc-cluster.yourdomain.com:9440
 PC_API_VERSION=v3 (Optional, defaults to v4. Supports v3, v4b1, v4)
 CLUSTER_REFRESH_INTERVAL=1800 (Seconds. Optional, defaults to 30 minutes)
 CLUSTER_PREFIX=optional-cluster-prefix to filter cluster names
+CONFIG_PATH=/etc/prometheus-nutanix-exporter/ (Optional, defaults to './configs')
 
 ### For HashiCorp Vault only
 VAULT_ADDR=https://your-vault-server.yourdomain.com

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	VaultRefreshInterval   time.Duration `env:"VAULT_REFRESH_INTERVAL" envDefault:"30m"`
 	PETaskAccount          string        `env:"PE_TASK_ACCOUNT"`
 	PCTaskAccount          string        `env:"PC_TASK_ACCOUNT"`
+	ConfigPath             string        `env:"CONFIG_PATH" envDefault:"./configs"`
 }
 
 func NewConfig() (*Config, error) {

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -168,10 +168,10 @@ func (es *ExporterService) refreshClusters() error {
 		// Register collectors for this cluster
 		slog.Info("Registering collectors for cluster", "name", name)
 		collectors := []prometheus.Collector{
-			prom.NewStorageContainerCollector(cluster, "configs/storage_container.yaml"),
-			prom.NewClusterCollector(cluster, "configs/cluster.yaml"),
-			prom.NewHostCollector(cluster, "configs/host.yaml"),
-			prom.NewVMCollector(cluster, "configs/vm.yaml"),
+			prom.NewStorageContainerCollector(cluster, es.config.ConfigPath + "/storage_container.yaml"),
+			prom.NewClusterCollector(cluster, es.config.ConfigPath + "/cluster.yaml"),
+			prom.NewHostCollector(cluster, es.config.ConfigPath + "/host.yaml"),
+			prom.NewVMCollector(cluster, es.config.ConfigPath + "/vm.yaml"),
 		}
 
 		for _, collector := range collectors {


### PR DESCRIPTION
# One-line summary

Allow storing YAML configuration files at a custom location.

## Description

This change makes it possible to store all relevant YAML configuration files in a custom directory, for example `/etc/prometheus-nutanix-exporter/`. 

The current default (`./configs`) remains unchanged.

This is useful when running the exporter outside of Docker, e.g. via Systemd or a similar service manager.

## Types of Changes

What types of changes does your code introduce? Keep the ones that apply:

- New feature (non-breaking change which adds functionality)
- Configuration change  
  - Introduces a new environment variable: `CONFIG_PATH`