### PR TITLE
xAdd public pkg/exporter API and StartWithServer/GetHandler methods

### DIFF
--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -54,6 +54,10 @@ func NewExporterService(cfg *config.Config, credProvider auth.CredentialProvider
 }
 
 func (es *ExporterService) Start() error {
+	return es.StartWithServer(true)
+}
+
+func (es *ExporterService) StartWithServer(startHTTPServer bool) error {
 	// Initialize Prism Central connection
 	if err := es.initializePrismCentral(); err != nil {
 		return fmt.Errorf("failed to initialize Prism Central: %w", err)
@@ -67,18 +71,33 @@ func (es *ExporterService) Start() error {
 	// Start refresh goroutines
 	es.startRefreshRoutines()
 
-	// Setup HTTP server
-	es.setupHTTPHandlers()
+	if startHTTPServer {
+		// Setup HTTP server
+		es.setupHTTPHandlers()
 
-	// Start server
-	go func() {
-		slog.Info("Starting server", "address", ListenAddress)
-		if err := es.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("Server error", "error", err)
-		}
-	}()
+		// Start server
+		go func() {
+			slog.Info("Starting server", "address", ListenAddress)
+			if err := es.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				slog.Error("Server error", "error", err)
+			}
+		}()
+	}
 
 	return nil
+}
+
+func (es *ExporterService) GetHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		es.clustersMu.RLock()
+		gatherers := make(prometheus.Gatherers, 0, len(es.clustersMap))
+		for _, cluster := range es.clustersMap {
+			cluster.RefreshCredentialsIfNeeded(es.credentialProvider)
+			gatherers = append(gatherers, cluster.Registry)
+		}
+		es.clustersMu.RUnlock()
+		promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+	})
 }
 
 func (es *ExporterService) Stop() error {

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -1,0 +1,76 @@
+/*
+Copyright © 2024 Ingka Holding B.V. All Rights Reserved.
+Licensed under the GPL, Version 2 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       <https://www.gnu.org/licenses/gpl-2.0.en.html>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package exporter provides a public API for embedding the Nutanix exporter
+// in other applications without starting its built-in HTTP server.
+package exporter
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/ingka-group/nutanix-exporter/internal/auth"
+	"github.com/ingka-group/nutanix-exporter/internal/config"
+	"github.com/ingka-group/nutanix-exporter/internal/service"
+)
+
+// Config holds configuration for the Nutanix exporter service.
+type Config struct {
+	PrismCentralURL        string
+	PrismCentralName       string
+	ClusterRefreshInterval time.Duration
+	ClusterPrefix          string
+	PCAPIVersion           string
+	ConfigPath             string
+}
+
+// CredentialProvider defines the interface for Nutanix credential management.
+type CredentialProvider = auth.CredentialProvider
+
+// ExporterService wraps the internal exporter service.
+type ExporterService struct {
+	svc *service.ExporterService
+}
+
+// NewExporterService creates a new ExporterService with the given configuration
+// and credential provider.
+func NewExporterService(cfg *Config, credProvider CredentialProvider) *ExporterService {
+	internalCfg := &config.Config{
+		PrismCentralURL:        cfg.PrismCentralURL,
+		PrismCentralName:       cfg.PrismCentralName,
+		ClusterRefreshInterval: cfg.ClusterRefreshInterval,
+		ClusterPrefix:          cfg.ClusterPrefix,
+		PCAPIVersion:           cfg.PCAPIVersion,
+		ConfigPath:             cfg.ConfigPath,
+	}
+	return &ExporterService{svc: service.NewExporterService(internalCfg, credProvider)}
+}
+
+// StartWithServer initializes the exporter. When startHTTPServer is true, the
+// built-in HTTP server is also started on the default listen address.
+func (es *ExporterService) StartWithServer(startHTTPServer bool) error {
+	return es.svc.StartWithServer(startHTTPServer)
+}
+
+// GetHandler returns an http.Handler that serves combined Prometheus metrics
+// from all discovered Nutanix clusters.
+func (es *ExporterService) GetHandler() http.Handler {
+	return es.svc.GetHandler()
+}
+
+// Stop shuts down the exporter service gracefully.
+func (es *ExporterService) Stop() error {
+	return es.svc.Stop()
+}


### PR DESCRIPTION
I'm working on integrating the nutanix-exporter into [Grafana Alloy](https://github.com/grafana/alloy) as a `prometheus.exporter.nutanix` component. The problem is that all the exporter's code lives under `internal/`, which Go won't let external modules import. This PR adds a public API so Alloy (and any other external project) can embed the exporter without needing to copy code or fork the repo.

## Changes

- Added `StartWithServer(startHTTPServer bool)` to `ExporterService`. This is the same as the existing `Start()` but lets callers skip starting the built-in HTTP server - useful when the caller (like Alloy) manages its own HTTP server and just needs to mount a handler. `Start()` still works exactly as before, it just calls `StartWithServer(true)` now.

- Added `GetHandler()` which returns an `http.Handler` that serves combined Prometheus metrics from all discovered clusters. It merges the per-cluster registries using `prometheus.Gatherers`.

- Added `pkg/exporter/exporter.go` as a thin public wrapper around the internal packages. It exposes `Config`, `CredentialProvider`, `ExporterService`, and `NewExporterService`.

I haven't touched any of the existing logic - the internal packages are unchanged apart from the new methods on `ExporterService`.