### PR TITLE
Refactor nutanix client

### DIFF
--- a/cmd/nutanix-exporter/main.go
+++ b/cmd/nutanix-exporter/main.go
@@ -55,16 +55,17 @@ func main() {
 		slog.Info("Using environment variable credential provider")
 	}
 
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
+	defer stop()
+
 	// Create and start exporter service
 	exporterService := service.NewExporterService(cfg, credProvider)
-	if err = exporterService.Start(); err != nil {
+	if err = exporterService.Start(ctx); err != nil {
 		slog.Error("Failed to start exporter service", "error", err)
 		os.Exit(1)
 	}
 
 	// Wait for shutdown signal
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
-	defer stop()
 	<-ctx.Done()
 
 	// Stop services and disconnect clients

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 )
 
+var nonAlphanumeric = regexp.MustCompile(`[^A-Z0-9_]+`)
+
 // EnvCredentialProvider implements the methods for getting Nutanix
 // cluster authentication credentials from environment variables.
 type EnvCredentialProvider struct{}
@@ -79,7 +81,5 @@ func (e *EnvCredentialProvider) GetPECreds(cluster string) (string, string, erro
 
 // convertClusterName converts the cluster name to uppercase and replaces non-alphanumeric characters with underscores.
 func (e *EnvCredentialProvider) convertClusterName(cluster string) string {
-	cluster = strings.ToUpper(cluster)
-	r, _ := regexp.Compile("[^A-Z0-9_]+")
-	return r.ReplaceAllString(cluster, "_")
+	return nonAlphanumeric.ReplaceAllString(strings.ToUpper(cluster), "_")
 }

--- a/internal/auth/vault.go
+++ b/internal/auth/vault.go
@@ -17,7 +17,6 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
@@ -108,7 +107,7 @@ func (v *VaultCredentialProvider) GetPECreds(cluster string) (string, string, er
 	return v.getCreds(cluster, v.peTaskAccount, v.engineName)
 }
 
-// GetCreds retrieves the credentials for a given cluster, path, and engine.
+// getCreds retrieves the credentials for a given cluster, path, and engine.
 func (v *VaultCredentialProvider) getCreds(cluster, path, engine string) (string, string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
 	defer cancel()
@@ -118,18 +117,13 @@ func (v *VaultCredentialProvider) getCreds(cluster, path, engine string) (string
 		return "", "", fmt.Errorf("failed to read secret: %w", err)
 	}
 
-	jsonData, err := json.Marshal(vaultResponse.Data.Data)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to marshal secret data: %w", err)
+	data := vaultResponse.Data.Data
+	username, _ := data["username"].(string)
+	secret, _ := data["secret"].(string)
+
+	if username == "" || secret == "" {
+		return "", "", fmt.Errorf("missing username or secret in vault response for cluster %s", cluster)
 	}
 
-	var vaultSecret struct {
-		Username string `json:"username"`
-		Secret   string `json:"secret"`
-	}
-	if err := json.Unmarshal(jsonData, &vaultSecret); err != nil {
-		return "", "", fmt.Errorf("failed to parse secret data: %w", err)
-	}
-
-	return vaultSecret.Username, vaultSecret.Secret, nil
+	return username, secret, nil
 }

--- a/internal/collector/exporter.go
+++ b/internal/collector/exporter.go
@@ -19,8 +19,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"os"
+	"time"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -41,15 +43,17 @@ type MetricConfig struct {
 type Exporter struct {
 	clusterName string
 	api         nutanix.NutanixClient
+	apiPath     string
 	metrics     map[string]*prometheus.GaugeVec
 	labels      []string
 }
 
 // NewExporter is the constructor for Exporter
-func NewExporter(clusterName string, api nutanix.NutanixClient, labels []string) *Exporter {
+func NewExporter(clusterName string, api nutanix.NutanixClient, apiPath string, labels []string) *Exporter {
 	return &Exporter{
 		clusterName: clusterName,
 		api:         api,
+		apiPath:     apiPath,
 		metrics:     make(map[string]*prometheus.GaugeVec),
 		labels:      labels,
 	}
@@ -105,10 +109,28 @@ func (e *Exporter) flattenMap(prefix string, nestedMap map[string]any) map[strin
 	return flatMap
 }
 
-// Describe method required by prometheus.Collector interface
+// Describe implements prometheus.Collector.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	for _, gaugeVec := range e.metrics {
 		gaugeVec.Describe(ch)
+	}
+}
+
+// Collect implements prometheus.Collector.
+func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := e.fetchData(ctx, e.apiPath)
+	if err != nil {
+		slog.Error("Error fetching data", "path", e.apiPath, "cluster", e.clusterName, "error", err)
+		return
+	}
+
+	e.updateMetrics(result)
+
+	for _, gaugeVec := range e.metrics {
+		gaugeVec.Collect(ch)
 	}
 }
 

--- a/internal/collector/exporter.go
+++ b/internal/collector/exporter.go
@@ -42,8 +42,8 @@ type MetricConfig struct {
 type Exporter struct {
 	clusterName string
 	api         nutanix.NutanixClient
-	Metrics     map[string]*prometheus.GaugeVec
-	Labels      []string
+	metrics     map[string]*prometheus.GaugeVec
+	labels      []string
 }
 
 // NewExporter is the constructor for Exporter
@@ -51,8 +51,8 @@ func NewExporter(clusterName string, api nutanix.NutanixClient, labels []string)
 	return &Exporter{
 		clusterName: clusterName,
 		api:         api,
-		Metrics:     make(map[string]*prometheus.GaugeVec),
-		Labels:      labels,
+		metrics:     make(map[string]*prometheus.GaugeVec),
+		labels:      labels,
 	}
 }
 
@@ -108,7 +108,7 @@ func (e *Exporter) flattenMap(prefix string, nestedMap map[string]any) map[strin
 
 // Describe method required by prometheus.Collector interface
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	for _, gaugeVec := range e.Metrics {
+	for _, gaugeVec := range e.metrics {
 		gaugeVec.Describe(ch)
 	}
 }
@@ -154,7 +154,7 @@ func (e *Exporter) initMetrics(configPath string, labelNames []string) error {
 	subsystem := strings.TrimSuffix(filepath.Base(configPath), filepath.Ext(configPath))
 
 	for _, m := range metrics {
-		e.Metrics[m.Name] = prometheus.NewGaugeVec(
+		e.metrics[m.Name] = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: "nutanix",
 				Subsystem: subsystem,
@@ -200,7 +200,7 @@ func (e *Exporter) processEntity(ent map[string]any, isCluster bool) {
 	for key, value := range flatEntity {
 		// Normalize the key and check if we're collecting this metric
 		normKey := e.normalizeKey(key)
-		if g, exists := e.Metrics[normKey]; exists {
+		if g, exists := e.metrics[normKey]; exists {
 			// Set label values and update the metric
 			var labelValues []string
 
@@ -231,7 +231,7 @@ func (e *Exporter) processMetadata(metadata map[string]any) {
 	for key, value := range flatMetadata {
 		// Normalize the key and check if we're collecting this metric
 		normKey := e.normalizeKey(key)
-		if g, exists := e.Metrics[normKey]; exists {
+		if g, exists := e.metrics[normKey]; exists {
 			// Set label values and update the metric
 			g.WithLabelValues(e.clusterName, "N/A").Set(e.valueToFloat64(value))
 		}

--- a/internal/collector/exporter.go
+++ b/internal/collector/exporter.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package prom
+package collector
 
 import (
 	"context"
@@ -40,17 +40,19 @@ type MetricConfig struct {
 
 // Exporter is the struct that gets extended by all other exporters
 type Exporter struct {
-	Cluster *nutanix.Cluster                // Reference to the parent Cluster struct
-	Metrics map[string]*prometheus.GaugeVec // Holds the metrics defined by the exporter
-	Labels  []string                        // Common labels for the metrics
+	clusterName string
+	api         nutanix.NutanixClient
+	Metrics     map[string]*prometheus.GaugeVec
+	Labels      []string
 }
 
 // NewExporter is the constructor for Exporter
-func NewExporter(cluster *nutanix.Cluster, labels []string) *Exporter {
+func NewExporter(clusterName string, api nutanix.NutanixClient, labels []string) *Exporter {
 	return &Exporter{
-		Cluster: cluster,
-		Metrics: make(map[string]*prometheus.GaugeVec),
-		Labels:  labels,
+		clusterName: clusterName,
+		api:         api,
+		Metrics:     make(map[string]*prometheus.GaugeVec),
+		Labels:      labels,
 	}
 }
 
@@ -113,7 +115,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 
 // fetchData makes a GET request to the given path and returns the response body as a map[string]any.
 func (e *Exporter) fetchData(ctx context.Context, path string) (result map[string]any, err error) {
-	resp, err := e.Cluster.API.MakeRequest(ctx, "GET", path)
+	resp, err := e.api.MakeRequest(ctx, "GET", path)
 	if err != nil {
 		return nil, err
 	}
@@ -204,17 +206,17 @@ func (e *Exporter) processEntity(ent map[string]any, isCluster bool) {
 
 			if isCluster {
 				// clustername is the only label for cluster-level metrics
-				labelValues = []string{e.Cluster.Name}
+				labelValues = []string{e.clusterName}
 			} else {
 				// For entity-level metrics, use both cluster name and entity name as labels
 				if name, ok := ent["name"].(string); ok {
-					labelValues = []string{e.Cluster.Name, name}
+					labelValues = []string{e.clusterName, name}
 					// Check for vmname key if name key is not present (used in VMv1 API)
 				} else if name, ok := ent["vmName"].(string); ok {
-					labelValues = []string{e.Cluster.Name, name}
+					labelValues = []string{e.clusterName, name}
 				} else {
 					// Handle case where "name" is missing or not a string
-					labelValues = []string{e.Cluster.Name, "unknown"}
+					labelValues = []string{e.clusterName, "unknown"}
 				}
 			}
 			g.WithLabelValues(labelValues...).Set(e.valueToFloat64(value))
@@ -231,7 +233,7 @@ func (e *Exporter) processMetadata(metadata map[string]any) {
 		normKey := e.normalizeKey(key)
 		if g, exists := e.Metrics[normKey]; exists {
 			// Set label values and update the metric
-			g.WithLabelValues(e.Cluster.Name, "N/A").Set(e.valueToFloat64(value))
+			g.WithLabelValues(e.clusterName, "N/A").Set(e.valueToFloat64(value))
 		}
 	}
 }

--- a/internal/collector/exporter.go
+++ b/internal/collector/exporter.go
@@ -61,7 +61,7 @@ func NewExporter(clusterName string, api nutanix.NutanixClient, apiPath string, 
 
 // valueToFloat64 converts a value to float64. Strings "on"/"off" (case-insensitive)
 // map to 1/0; other strings are parsed as floats.
-func (e *Exporter) valueToFloat64(value any) float64 {
+func valueToFloat64(value any) float64 {
 	switch v := value.(type) {
 	case float64:
 		return v
@@ -85,7 +85,7 @@ func (e *Exporter) valueToFloat64(value any) float64 {
 }
 
 // normalizeKey normalizes given key to lowercase and replaces . and - with _
-func (e *Exporter) normalizeKey(key string) string {
+func normalizeKey(key string) string {
 	return strings.ToLower(strings.NewReplacer(".", "_", "-", "_", ":", "_").Replace(key))
 }
 
@@ -219,7 +219,7 @@ func (e *Exporter) processEntity(ent map[string]any, isCluster bool) {
 	// Iterate over the flattened map and update the metrics
 	for key, value := range flatEntity {
 		// Normalize the key and check if we're collecting this metric
-		normKey := e.normalizeKey(key)
+		normKey := normalizeKey(key)
 		if g, exists := e.metrics[normKey]; exists {
 			// Set label values and update the metric
 			var labelValues []string
@@ -239,7 +239,7 @@ func (e *Exporter) processEntity(ent map[string]any, isCluster bool) {
 					labelValues = []string{e.clusterName, "unknown"}
 				}
 			}
-			g.WithLabelValues(labelValues...).Set(e.valueToFloat64(value))
+			g.WithLabelValues(labelValues...).Set(valueToFloat64(value))
 		}
 	}
 }
@@ -250,10 +250,10 @@ func (e *Exporter) processMetadata(metadata map[string]any) {
 	flatMetadata := e.flattenMap("", metadata)
 	for key, value := range flatMetadata {
 		// Normalize the key and check if we're collecting this metric
-		normKey := e.normalizeKey(key)
+		normKey := normalizeKey(key)
 		if g, exists := e.metrics[normKey]; exists {
 			// Set label values and update the metric
-			g.WithLabelValues(e.clusterName, "N/A").Set(e.valueToFloat64(value))
+			g.WithLabelValues(e.clusterName, "N/A").Set(valueToFloat64(value))
 		}
 	}
 }

--- a/internal/collector/exporter.go
+++ b/internal/collector/exporter.go
@@ -18,7 +18,6 @@ package collector
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 
 	"os"
@@ -121,9 +120,25 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := e.fetchData(ctx, e.apiPath)
+	resp, err := e.api.MakeRequest(ctx, "GET", e.apiPath)
 	if err != nil {
 		slog.Error("Error fetching data", "path", e.apiPath, "cluster", e.clusterName, "error", err)
+		return
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			slog.Error("Error closing response body", "path", e.apiPath, "cluster", e.clusterName, "error", cerr)
+		}
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		slog.Error("Error fetching data", "path", e.apiPath, "cluster", e.clusterName, "status", resp.Status)
+		return
+	}
+
+	var result map[string]any
+	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		slog.Error("Error decoding response", "path", e.apiPath, "cluster", e.clusterName, "error", err)
 		return
 	}
 
@@ -132,29 +147,6 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	for _, gaugeVec := range e.metrics {
 		gaugeVec.Collect(ch)
 	}
-}
-
-// fetchData makes a GET request to the given path and returns the response body as a map[string]any.
-func (e *Exporter) fetchData(ctx context.Context, path string) (result map[string]any, err error) {
-	resp, err := e.api.MakeRequest(ctx, "GET", path)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("request failed: %s", resp.Status)
-	}
-
-	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response body: %w", err)
-	}
-
-	return result, nil
 }
 
 // initMetrics populates e.metrics from parsed YAML bytes and the subsystem name.

--- a/internal/collector/exporter.go
+++ b/internal/collector/exporter.go
@@ -157,21 +157,12 @@ func (e *Exporter) fetchData(ctx context.Context, path string) (result map[strin
 	return result, nil
 }
 
-// initMetrics initializes metrics based on the provided config file and labels.
-func (e *Exporter) initMetrics(configPath string, labelNames []string) error {
-	yamlFile, err := os.ReadFile(configPath)
-	if err != nil {
-		return err
-	}
-
+// initMetrics populates e.metrics from parsed YAML bytes and the subsystem name.
+func (e *Exporter) initMetrics(subsystem string, data []byte, labelNames []string) error {
 	var metrics []MetricConfig
-	err = yaml.Unmarshal(yamlFile, &metrics)
-	if err != nil {
+	if err := yaml.Unmarshal(data, &metrics); err != nil {
 		return err
 	}
-
-	// Use the filename without extension as the subsystem
-	subsystem := strings.TrimSuffix(filepath.Base(configPath), filepath.Ext(configPath))
 
 	for _, m := range metrics {
 		e.metrics[m.Name] = prometheus.NewGaugeVec(
@@ -186,6 +177,16 @@ func (e *Exporter) initMetrics(configPath string, labelNames []string) error {
 	}
 
 	return nil
+}
+
+// initMetricsFromFile reads configPath and delegates to initMetrics.
+func (e *Exporter) initMetricsFromFile(configPath string, labelNames []string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+	subsystem := strings.TrimSuffix(filepath.Base(configPath), filepath.Ext(configPath))
+	return e.initMetrics(subsystem, data, labelNames)
 }
 
 // updateMetrics processes the JSON structure for hosts and updates the metrics.

--- a/internal/collector/exporter.go
+++ b/internal/collector/exporter.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	"os"
 	"path/filepath"
@@ -130,8 +129,7 @@ func (e *Exporter) fetchData(ctx context.Context, path string) (result map[strin
 	}
 
 	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		slog.Error("Error decoding response body", "error", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	return result, nil

--- a/internal/collector/exporters.go
+++ b/internal/collector/exporters.go
@@ -19,81 +19,47 @@ import (
 	"github.com/ingka-group/nutanix-exporter/internal/nutanix"
 )
 
-// ----- Type Definitions ----- //
-
-type ClusterExporter struct {
-	*Exporter
-}
-
-type HostsExporter struct {
-	*Exporter
-}
-
-type VmExporter struct {
-	*Exporter
-}
-
-type Vmv1Exporter struct {
-	*Exporter
-}
-
-type StorageContainerExporter struct {
-	*Exporter
-}
-
-// ----- Constructors ----- //
-
-func NewClusterCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*ClusterExporter, error) {
+func NewClusterCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*Exporter, error) {
 	labels := []string{"cluster_name"}
-	exporter := &ClusterExporter{
-		Exporter: NewExporter(clusterName, api, "/v2.0/cluster/", labels),
-	}
-	if err := exporter.initMetricsFromFile(configPath, labels); err != nil {
+	e := NewExporter(clusterName, api, "/v2.0/cluster/", labels)
+	if err := e.initMetricsFromFile(configPath, labels); err != nil {
 		return nil, err
 	}
-	return exporter, nil
+	return e, nil
 }
 
-func NewHostCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*HostsExporter, error) {
+func NewHostCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*Exporter, error) {
 	labels := []string{"cluster_name", "host_name"}
-	exporter := &HostsExporter{
-		Exporter: NewExporter(clusterName, api, "/v2.0/hosts/", labels),
-	}
-	if err := exporter.initMetricsFromFile(configPath, labels); err != nil {
+	e := NewExporter(clusterName, api, "/v2.0/hosts/", labels)
+	if err := e.initMetricsFromFile(configPath, labels); err != nil {
 		return nil, err
 	}
-	return exporter, nil
+	return e, nil
 }
 
-func NewVMCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*VmExporter, error) {
+func NewVMCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*Exporter, error) {
 	labels := []string{"cluster_name", "vm_name"}
-	exporter := &VmExporter{
-		Exporter: NewExporter(clusterName, api, "/v2.0/vms/", labels),
-	}
-	if err := exporter.initMetricsFromFile(configPath, labels); err != nil {
+	e := NewExporter(clusterName, api, "/v2.0/vms/", labels)
+	if err := e.initMetricsFromFile(configPath, labels); err != nil {
 		return nil, err
 	}
-	return exporter, nil
+	return e, nil
 }
 
-func NewVMv1Collector(clusterName string, api nutanix.NutanixClient, configPath string) (*Vmv1Exporter, error) {
+func NewVMv1Collector(clusterName string, api nutanix.NutanixClient, configPath string) (*Exporter, error) {
 	labels := []string{"cluster_name", "vm_name"}
-	exporter := &Vmv1Exporter{
-		Exporter: NewExporter(clusterName, api, "/v1/vms/", labels),
-	}
-	if err := exporter.initMetricsFromFile(configPath, labels); err != nil {
+	e := NewExporter(clusterName, api, "/v1/vms/", labels)
+	if err := e.initMetricsFromFile(configPath, labels); err != nil {
 		return nil, err
 	}
-	return exporter, nil
+	return e, nil
 }
 
-func NewStorageContainerCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*StorageContainerExporter, error) {
+func NewStorageContainerCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*Exporter, error) {
 	labels := []string{"cluster_name", "container_name"}
-	exporter := &StorageContainerExporter{
-		Exporter: NewExporter(clusterName, api, "/v2.0/storage_containers/", labels),
-	}
-	if err := exporter.initMetricsFromFile(configPath, labels); err != nil {
+	e := NewExporter(clusterName, api, "/v2.0/storage_containers/", labels)
+	if err := e.initMetricsFromFile(configPath, labels); err != nil {
 		return nil, err
 	}
-	return exporter, nil
+	return e, nil
 }

--- a/internal/collector/exporters.go
+++ b/internal/collector/exporters.go
@@ -16,14 +16,7 @@ limitations under the License.
 package collector
 
 import (
-	"context"
-	"time"
-
-	"log/slog"
-
 	"github.com/ingka-group/nutanix-exporter/internal/nutanix"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // ----- Type Definitions ----- //
@@ -53,7 +46,7 @@ type StorageContainerExporter struct {
 func NewClusterCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*ClusterExporter, error) {
 	labels := []string{"cluster_name"}
 	exporter := &ClusterExporter{
-		Exporter: NewExporter(clusterName, api, labels),
+		Exporter: NewExporter(clusterName, api, "/v2.0/cluster/", labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -64,7 +57,7 @@ func NewClusterCollector(clusterName string, api nutanix.NutanixClient, configPa
 func NewHostCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*HostsExporter, error) {
 	labels := []string{"cluster_name", "host_name"}
 	exporter := &HostsExporter{
-		Exporter: NewExporter(clusterName, api, labels),
+		Exporter: NewExporter(clusterName, api, "/v2.0/hosts/", labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -75,7 +68,7 @@ func NewHostCollector(clusterName string, api nutanix.NutanixClient, configPath 
 func NewVMCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*VmExporter, error) {
 	labels := []string{"cluster_name", "vm_name"}
 	exporter := &VmExporter{
-		Exporter: NewExporter(clusterName, api, labels),
+		Exporter: NewExporter(clusterName, api, "/v2.0/vms/", labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -86,7 +79,7 @@ func NewVMCollector(clusterName string, api nutanix.NutanixClient, configPath st
 func NewVMv1Collector(clusterName string, api nutanix.NutanixClient, configPath string) (*Vmv1Exporter, error) {
 	labels := []string{"cluster_name", "vm_name"}
 	exporter := &Vmv1Exporter{
-		Exporter: NewExporter(clusterName, api, labels),
+		Exporter: NewExporter(clusterName, api, "/v1/vms/", labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -97,102 +90,10 @@ func NewVMv1Collector(clusterName string, api nutanix.NutanixClient, configPath 
 func NewStorageContainerCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*StorageContainerExporter, error) {
 	labels := []string{"cluster_name", "container_name"}
 	exporter := &StorageContainerExporter{
-		Exporter: NewExporter(clusterName, api, labels),
+		Exporter: NewExporter(clusterName, api, "/v2.0/storage_containers/", labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
 	}
 	return exporter, nil
-}
-
-// ----- Collect Methods ----- //
-
-// Collect
-func (e *StorageContainerExporter) Collect(ch chan<- prometheus.Metric) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	result, err := e.fetchData(ctx, "/v2.0/storage_containers/")
-	if err != nil {
-		slog.Error("Error fetching storage container data", "error", err)
-		return
-	}
-
-	e.updateMetrics(result)
-
-	for _, gaugeVec := range e.metrics {
-		gaugeVec.Collect(ch)
-	}
-}
-
-// Collect
-func (e *ClusterExporter) Collect(ch chan<- prometheus.Metric) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	result, err := e.fetchData(ctx, "/v2.0/cluster/")
-	if err != nil {
-		slog.Error("Error fetching cluster data", "error", err)
-		return
-	}
-
-	e.updateMetrics(result)
-
-	for _, gaugeVec := range e.metrics {
-		gaugeVec.Collect(ch)
-	}
-}
-
-// Collect
-func (e *HostsExporter) Collect(ch chan<- prometheus.Metric) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	result, err := e.fetchData(ctx, "/v2.0/hosts/")
-	if err != nil {
-		slog.Error("Error fetching host data", "error", err)
-		return
-	}
-
-	e.updateMetrics(result)
-
-	for _, gaugeVec := range e.metrics {
-		gaugeVec.Collect(ch)
-	}
-}
-
-// Collect
-func (e *VmExporter) Collect(ch chan<- prometheus.Metric) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	result, err := e.fetchData(ctx, "/v2.0/vms/")
-	if err != nil {
-		slog.Error("Error fetching VM data", "error", err)
-		return
-	}
-
-	e.updateMetrics(result)
-
-	for _, gaugeVec := range e.metrics {
-		gaugeVec.Collect(ch)
-	}
-}
-
-// Collect
-func (e *Vmv1Exporter) Collect(ch chan<- prometheus.Metric) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	result, err := e.fetchData(ctx, "/v1/vms/")
-	if err != nil {
-		slog.Error("Error fetching VM v1 data", "error", err)
-		return
-	}
-
-	e.updateMetrics(result)
-
-	for _, gaugeVec := range e.metrics {
-		gaugeVec.Collect(ch)
-	}
 }

--- a/internal/collector/exporters.go
+++ b/internal/collector/exporters.go
@@ -50,10 +50,10 @@ type StorageContainerExporter struct {
 
 // ----- Constructors ----- //
 
-func NewClusterCollector(cluster *nutanix.Cluster, configPath string) (*ClusterExporter, error) {
+func NewClusterCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*ClusterExporter, error) {
 	labels := []string{"cluster_name"}
 	exporter := &ClusterExporter{
-		Exporter: NewExporter(cluster.Name, cluster.API, labels),
+		Exporter: NewExporter(clusterName, api, labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -61,10 +61,10 @@ func NewClusterCollector(cluster *nutanix.Cluster, configPath string) (*ClusterE
 	return exporter, nil
 }
 
-func NewHostCollector(cluster *nutanix.Cluster, configPath string) (*HostsExporter, error) {
+func NewHostCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*HostsExporter, error) {
 	labels := []string{"cluster_name", "host_name"}
 	exporter := &HostsExporter{
-		Exporter: NewExporter(cluster.Name, cluster.API, labels),
+		Exporter: NewExporter(clusterName, api, labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -72,10 +72,10 @@ func NewHostCollector(cluster *nutanix.Cluster, configPath string) (*HostsExport
 	return exporter, nil
 }
 
-func NewVMCollector(cluster *nutanix.Cluster, configPath string) (*VmExporter, error) {
+func NewVMCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*VmExporter, error) {
 	labels := []string{"cluster_name", "vm_name"}
 	exporter := &VmExporter{
-		Exporter: NewExporter(cluster.Name, cluster.API, labels),
+		Exporter: NewExporter(clusterName, api, labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -83,10 +83,10 @@ func NewVMCollector(cluster *nutanix.Cluster, configPath string) (*VmExporter, e
 	return exporter, nil
 }
 
-func NewVMv1Collector(cluster *nutanix.Cluster, configPath string) (*Vmv1Exporter, error) {
+func NewVMv1Collector(clusterName string, api nutanix.NutanixClient, configPath string) (*Vmv1Exporter, error) {
 	labels := []string{"cluster_name", "vm_name"}
 	exporter := &Vmv1Exporter{
-		Exporter: NewExporter(cluster.Name, cluster.API, labels),
+		Exporter: NewExporter(clusterName, api, labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -94,10 +94,10 @@ func NewVMv1Collector(cluster *nutanix.Cluster, configPath string) (*Vmv1Exporte
 	return exporter, nil
 }
 
-func NewStorageContainerCollector(cluster *nutanix.Cluster, configPath string) (*StorageContainerExporter, error) {
+func NewStorageContainerCollector(clusterName string, api nutanix.NutanixClient, configPath string) (*StorageContainerExporter, error) {
 	labels := []string{"cluster_name", "container_name"}
 	exporter := &StorageContainerExporter{
-		Exporter: NewExporter(cluster.Name, cluster.API, labels),
+		Exporter: NewExporter(clusterName, api, labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err

--- a/internal/collector/exporters.go
+++ b/internal/collector/exporters.go
@@ -120,7 +120,7 @@ func (e *StorageContainerExporter) Collect(ch chan<- prometheus.Metric) {
 
 	e.updateMetrics(result)
 
-	for _, gaugeVec := range e.Metrics {
+	for _, gaugeVec := range e.metrics {
 		gaugeVec.Collect(ch)
 	}
 }
@@ -138,7 +138,7 @@ func (e *ClusterExporter) Collect(ch chan<- prometheus.Metric) {
 
 	e.updateMetrics(result)
 
-	for _, gaugeVec := range e.Metrics {
+	for _, gaugeVec := range e.metrics {
 		gaugeVec.Collect(ch)
 	}
 }
@@ -156,7 +156,7 @@ func (e *HostsExporter) Collect(ch chan<- prometheus.Metric) {
 
 	e.updateMetrics(result)
 
-	for _, gaugeVec := range e.Metrics {
+	for _, gaugeVec := range e.metrics {
 		gaugeVec.Collect(ch)
 	}
 }
@@ -174,7 +174,7 @@ func (e *VmExporter) Collect(ch chan<- prometheus.Metric) {
 
 	e.updateMetrics(result)
 
-	for _, gaugeVec := range e.Metrics {
+	for _, gaugeVec := range e.metrics {
 		gaugeVec.Collect(ch)
 	}
 }
@@ -192,7 +192,7 @@ func (e *Vmv1Exporter) Collect(ch chan<- prometheus.Metric) {
 
 	e.updateMetrics(result)
 
-	for _, gaugeVec := range e.Metrics {
+	for _, gaugeVec := range e.metrics {
 		gaugeVec.Collect(ch)
 	}
 }

--- a/internal/collector/exporters.go
+++ b/internal/collector/exporters.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package prom
+package collector
 
 import (
 	"context"
@@ -53,7 +53,7 @@ type StorageContainerExporter struct {
 func NewClusterCollector(cluster *nutanix.Cluster, configPath string) (*ClusterExporter, error) {
 	labels := []string{"cluster_name"}
 	exporter := &ClusterExporter{
-		Exporter: NewExporter(cluster, labels),
+		Exporter: NewExporter(cluster.Name, cluster.API, labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func NewClusterCollector(cluster *nutanix.Cluster, configPath string) (*ClusterE
 func NewHostCollector(cluster *nutanix.Cluster, configPath string) (*HostsExporter, error) {
 	labels := []string{"cluster_name", "host_name"}
 	exporter := &HostsExporter{
-		Exporter: NewExporter(cluster, labels),
+		Exporter: NewExporter(cluster.Name, cluster.API, labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func NewHostCollector(cluster *nutanix.Cluster, configPath string) (*HostsExport
 func NewVMCollector(cluster *nutanix.Cluster, configPath string) (*VmExporter, error) {
 	labels := []string{"cluster_name", "vm_name"}
 	exporter := &VmExporter{
-		Exporter: NewExporter(cluster, labels),
+		Exporter: NewExporter(cluster.Name, cluster.API, labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func NewVMCollector(cluster *nutanix.Cluster, configPath string) (*VmExporter, e
 func NewVMv1Collector(cluster *nutanix.Cluster, configPath string) (*Vmv1Exporter, error) {
 	labels := []string{"cluster_name", "vm_name"}
 	exporter := &Vmv1Exporter{
-		Exporter: NewExporter(cluster, labels),
+		Exporter: NewExporter(cluster.Name, cluster.API, labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func NewVMv1Collector(cluster *nutanix.Cluster, configPath string) (*Vmv1Exporte
 func NewStorageContainerCollector(cluster *nutanix.Cluster, configPath string) (*StorageContainerExporter, error) {
 	labels := []string{"cluster_name", "container_name"}
 	exporter := &StorageContainerExporter{
-		Exporter: NewExporter(cluster, labels),
+		Exporter: NewExporter(cluster.Name, cluster.API, labels),
 	}
 	if err := exporter.initMetrics(configPath, labels); err != nil {
 		return nil, err

--- a/internal/collector/exporters.go
+++ b/internal/collector/exporters.go
@@ -48,7 +48,7 @@ func NewClusterCollector(clusterName string, api nutanix.NutanixClient, configPa
 	exporter := &ClusterExporter{
 		Exporter: NewExporter(clusterName, api, "/v2.0/cluster/", labels),
 	}
-	if err := exporter.initMetrics(configPath, labels); err != nil {
+	if err := exporter.initMetricsFromFile(configPath, labels); err != nil {
 		return nil, err
 	}
 	return exporter, nil
@@ -59,7 +59,7 @@ func NewHostCollector(clusterName string, api nutanix.NutanixClient, configPath 
 	exporter := &HostsExporter{
 		Exporter: NewExporter(clusterName, api, "/v2.0/hosts/", labels),
 	}
-	if err := exporter.initMetrics(configPath, labels); err != nil {
+	if err := exporter.initMetricsFromFile(configPath, labels); err != nil {
 		return nil, err
 	}
 	return exporter, nil
@@ -70,7 +70,7 @@ func NewVMCollector(clusterName string, api nutanix.NutanixClient, configPath st
 	exporter := &VmExporter{
 		Exporter: NewExporter(clusterName, api, "/v2.0/vms/", labels),
 	}
-	if err := exporter.initMetrics(configPath, labels); err != nil {
+	if err := exporter.initMetricsFromFile(configPath, labels); err != nil {
 		return nil, err
 	}
 	return exporter, nil
@@ -81,7 +81,7 @@ func NewVMv1Collector(clusterName string, api nutanix.NutanixClient, configPath 
 	exporter := &Vmv1Exporter{
 		Exporter: NewExporter(clusterName, api, "/v1/vms/", labels),
 	}
-	if err := exporter.initMetrics(configPath, labels); err != nil {
+	if err := exporter.initMetricsFromFile(configPath, labels); err != nil {
 		return nil, err
 	}
 	return exporter, nil
@@ -92,7 +92,7 @@ func NewStorageContainerCollector(clusterName string, api nutanix.NutanixClient,
 	exporter := &StorageContainerExporter{
 		Exporter: NewExporter(clusterName, api, "/v2.0/storage_containers/", labels),
 	}
-	if err := exporter.initMetrics(configPath, labels); err != nil {
+	if err := exporter.initMetricsFromFile(configPath, labels); err != nil {
 		return nil, err
 	}
 	return exporter, nil

--- a/internal/nutanix/clusters.go
+++ b/internal/nutanix/clusters.go
@@ -78,19 +78,19 @@ func FetchClusters(ctx context.Context, client NutanixClient, apiVersion, prefix
 	switch apiVersion {
 	case "v3":
 		makeRequest = func(ctx context.Context, page int) (*http.Response, error) {
-			return makeV3Request(ctx, client, page)
+			return fetchClustersV3(ctx, client, page)
 		}
-		parseClusters = parseV3Clusters
+		parseClusters = parseClustersV3
 	case "v4b1":
 		makeRequest = func(ctx context.Context, page int) (*http.Response, error) {
-			return makeV4b1Request(ctx, client, page)
+			return fetchClustersV4b1(ctx, client, page)
 		}
-		parseClusters = parseV4Clusters
+		parseClusters = parseClustersV4
 	default: // v4
 		makeRequest = func(ctx context.Context, page int) (*http.Response, error) {
-			return makeV4Request(ctx, client, page)
+			return fetchClustersV4(ctx, client, page)
 		}
-		parseClusters = parseV4Clusters
+		parseClusters = parseClustersV4
 	}
 
 	clusterData := make(map[string]string)
@@ -190,7 +190,7 @@ func FetchClusters(ctx context.Context, client NutanixClient, apiVersion, prefix
 	return clusterData, nil
 }
 
-func makeV3Request(ctx context.Context, client NutanixClient, page int) (*http.Response, error) {
+func fetchClustersV3(ctx context.Context, client NutanixClient, page int) (*http.Response, error) {
 	return client.MakeRequest(ctx, "POST", "/api/nutanix/v3/clusters/list", RequestOptions{
 		Payload: map[string]any{
 			"kind":   "cluster",
@@ -200,7 +200,7 @@ func makeV3Request(ctx context.Context, client NutanixClient, page int) (*http.R
 	})
 }
 
-func makeV4Request(ctx context.Context, client NutanixClient, page int) (*http.Response, error) {
+func fetchClustersV4(ctx context.Context, client NutanixClient, page int) (*http.Response, error) {
 	return client.MakeRequest(ctx, "GET", "/api/clustermgmt/v4.0/config/clusters", RequestOptions{
 		Params: url.Values{
 			"$limit":   []string{"100"},
@@ -210,7 +210,7 @@ func makeV4Request(ctx context.Context, client NutanixClient, page int) (*http.R
 	})
 }
 
-func makeV4b1Request(ctx context.Context, client NutanixClient, page int) (*http.Response, error) {
+func fetchClustersV4b1(ctx context.Context, client NutanixClient, page int) (*http.Response, error) {
 	return client.MakeRequest(ctx, "GET", "/api/clustermgmt/v4.0.b1/config/clusters", RequestOptions{
 		Params: url.Values{
 			"$limit":   []string{"100"},
@@ -220,7 +220,7 @@ func makeV4b1Request(ctx context.Context, client NutanixClient, page int) (*http
 	})
 }
 
-func parseV3Clusters(result map[string]any) ([]map[string]string, int, error) {
+func parseClustersV3(result map[string]any) ([]map[string]string, int, error) {
 	entities, ok := result["entities"].([]any)
 	if !ok {
 		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'entities' field")
@@ -280,7 +280,7 @@ func parseV3Clusters(result map[string]any) ([]map[string]string, int, error) {
 	return clusters, totalCount - unnamedCount, nil
 }
 
-func parseV4Clusters(result map[string]any) ([]map[string]string, int, error) {
+func parseClustersV4(result map[string]any) ([]map[string]string, int, error) {
 	data, ok := result["data"].([]any)
 	if !ok {
 		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'data' field")

--- a/internal/nutanix/clusters.go
+++ b/internal/nutanix/clusters.go
@@ -1,0 +1,340 @@
+/*
+Copyright © 2024 Ingka Holding B.V. All Rights Reserved.
+Licensed under the GPL, Version 2 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       <https://www.gnu.org/licenses/gpl-2.0.en.html>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nutanix
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ingka-group/nutanix-exporter/internal/auth"
+)
+
+// Cluster represents a Nutanix cluster (Prism Central OR Element).
+type Cluster struct {
+	Name string
+	URL  string `yaml:"URL"`
+	API  NutanixClient
+}
+
+// NewCluster returns a new Nutanix Cluster, fetching credentials and constructing the API client.
+// Returns nil if credentials cannot be obtained.
+func NewCluster(name, rawURL string, ncp auth.CredentialProvider, isPC bool, skipTLSVerify bool, timeout time.Duration) *Cluster {
+	var username, password string
+	var err error
+
+	if isPC {
+		username, password, err = ncp.GetPCCreds(name)
+	} else {
+		username, password, err = ncp.GetPECreds(name)
+	}
+
+	if username == "" || password == "" {
+		kind := "Prism Element"
+		if isPC {
+			kind = "Prism Central"
+		}
+		slog.Error("Failed to get credentials", "kind", kind, "name", name, "error", err)
+		return nil
+	}
+
+	api := newClient(name, rawURL, username, password, ncp, isPC, skipTLSVerify, timeout)
+
+	return &Cluster{
+		Name: name,
+		URL:  rawURL,
+		API:  api,
+	}
+}
+
+// FetchClusters queries Prism Central via client and returns a map of cluster name -> URL.
+// apiVersion selects the PC API variant ("v3", "v4b1", or "v4" / anything else).
+// prefix, when non-empty, filters clusters whose names don't start with it.
+func FetchClusters(ctx context.Context, client NutanixClient, apiVersion, prefix string) (map[string]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	var makeRequest func(context.Context, int) (*http.Response, error)
+	var parseClusters func(map[string]any) ([]map[string]string, int, error)
+
+	switch apiVersion {
+	case "v3":
+		makeRequest = func(ctx context.Context, page int) (*http.Response, error) {
+			return makeV3Request(ctx, client, page)
+		}
+		parseClusters = parseV3Clusters
+	case "v4b1":
+		makeRequest = func(ctx context.Context, page int) (*http.Response, error) {
+			return makeV4b1Request(ctx, client, page)
+		}
+		parseClusters = parseV4Clusters
+	default: // v4
+		makeRequest = func(ctx context.Context, page int) (*http.Response, error) {
+			return makeV4Request(ctx, client, page)
+		}
+		parseClusters = parseV4Clusters
+	}
+
+	clusterData := make(map[string]string)
+	page := 0
+	totalExpected := 0
+	totalFetched := 0
+
+	slog.Info("Fetching clusters", "api_version", apiVersion)
+
+	for {
+		slog.Info("Fetching clusters page", "page", page)
+
+		resp, err := makeRequest(ctx, page)
+		if err != nil {
+			return nil, fmt.Errorf("failed to make API request for page %d: %w", page, err)
+		}
+
+		var result map[string]any
+		decodeErr := func() (err error) {
+			defer func() {
+				if cerr := resp.Body.Close(); cerr != nil && err == nil {
+					err = cerr
+				}
+			}()
+			return json.NewDecoder(resp.Body).Decode(&result)
+		}()
+		if decodeErr != nil {
+			return nil, fmt.Errorf("failed to decode response for page %d: %w", page, decodeErr)
+		}
+
+		clusters, total, err := parseClusters(result)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse clusters for page %d: %w", page, err)
+		}
+
+		if page == 0 {
+			totalExpected = total
+			slog.Info("Total clusters available", "total", totalExpected)
+		}
+
+		pageClusterCount := 0
+		duplicateCount := 0
+		for _, cluster := range clusters {
+			name := cluster["name"]
+			ip := cluster["ip"]
+
+			if prefix != "" && !strings.HasPrefix(name, prefix) {
+				slog.Info("Skipping cluster due to prefix filter", "name", name, "prefix", prefix)
+				continue
+			}
+
+			if _, exists := clusterData[name]; exists {
+				duplicateCount++
+				slog.Info("Skipping duplicate cluster", "name", name)
+				continue
+			}
+
+			clusterData[name] = fmt.Sprintf("https://%s:9440", ip)
+			slog.Info("Found cluster", "name", name, "url", clusterData[name])
+			pageClusterCount++
+		}
+
+		totalFetched += len(clusters)
+
+		slog.Info("Processed clusters from page",
+			"page", page,
+			"clusters_on_page", len(clusters),
+			"new_clusters", pageClusterCount,
+			"duplicates", duplicateCount,
+			"total_fetched", totalFetched,
+			"total_unique", len(clusterData))
+
+		if duplicateCount == len(clusters) && len(clusters) > 0 {
+			slog.Info("All clusters on page were duplicates, stopping pagination", "page", page)
+			break
+		}
+
+		if len(clusters) < 100 {
+			slog.Info("Received partial page, stopping pagination",
+				"page", page,
+				"clusters_on_page", len(clusters))
+			break
+		}
+
+		page++
+
+		if page > 49 {
+			slog.Warn("Reached maximum page limit, stopping pagination", "max_pages", 50)
+			break
+		}
+	}
+
+	slog.Info("Completed fetching all clusters",
+		"total_api_reported", totalExpected,
+		"total_clusters_fetched", totalFetched,
+		"total_unique_clusters", len(clusterData))
+	return clusterData, nil
+}
+
+func makeV3Request(ctx context.Context, client NutanixClient, page int) (*http.Response, error) {
+	return client.MakeRequest(ctx, "POST", "/api/nutanix/v3/clusters/list", RequestOptions{
+		Payload: map[string]any{
+			"kind":   "cluster",
+			"length": 100,
+			"offset": page * 100,
+		},
+	})
+}
+
+func makeV4Request(ctx context.Context, client NutanixClient, page int) (*http.Response, error) {
+	return client.MakeRequest(ctx, "GET", "/api/clustermgmt/v4.0/config/clusters", RequestOptions{
+		Params: url.Values{
+			"$limit":   []string{"100"},
+			"$page":    []string{fmt.Sprintf("%d", page)},
+			"$orderby": []string{"name"},
+		},
+	})
+}
+
+func makeV4b1Request(ctx context.Context, client NutanixClient, page int) (*http.Response, error) {
+	return client.MakeRequest(ctx, "GET", "/api/clustermgmt/v4.0.b1/config/clusters", RequestOptions{
+		Params: url.Values{
+			"$limit":   []string{"100"},
+			"$page":    []string{fmt.Sprintf("%d", page)},
+			"$orderby": []string{"name"},
+		},
+	})
+}
+
+func parseV3Clusters(result map[string]any) ([]map[string]string, int, error) {
+	entities, ok := result["entities"].([]any)
+	if !ok {
+		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'entities' field")
+	}
+
+	metadata, ok := result["metadata"].(map[string]any)
+	if !ok {
+		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'metadata' field")
+	}
+	totalMatches, ok := metadata["total_matches"].(float64)
+	if !ok {
+		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'total_matches' field")
+	}
+	totalCount := int(totalMatches)
+
+	var clusters []map[string]string
+	unnamedCount := 0
+	for _, entity := range entities {
+		cluster, ok := entity.(map[string]any)
+		if !ok {
+			continue
+		}
+		spec, ok := cluster["spec"].(map[string]any)
+		if !ok {
+			continue
+		}
+		status, ok := cluster["status"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, ok := spec["name"].(string)
+		if !ok || name == "" || name == "Unnamed" {
+			unnamedCount++
+			continue
+		}
+
+		resources, ok := status["resources"].(map[string]any)
+		if !ok {
+			continue
+		}
+		network, ok := resources["network"].(map[string]any)
+		if !ok {
+			continue
+		}
+		ip, ok := network["external_ip"].(string)
+		if !ok || ip == "" {
+			continue
+		}
+
+		clusters = append(clusters, map[string]string{
+			"name": name,
+			"ip":   ip,
+		})
+	}
+
+	return clusters, totalCount - unnamedCount, nil
+}
+
+func parseV4Clusters(result map[string]any) ([]map[string]string, int, error) {
+	data, ok := result["data"].([]any)
+	if !ok {
+		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'data' field")
+	}
+
+	metadata, ok := result["metadata"].(map[string]any)
+	if !ok {
+		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'metadata' field")
+	}
+	totalAvailable, ok := metadata["totalAvailableResults"].(float64)
+	if !ok {
+		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'totalAvailableResults' field")
+	}
+	totalCount := int(totalAvailable)
+
+	var clusters []map[string]string
+	unnamedCount := 0
+	for _, item := range data {
+		clusterMap, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, ok := clusterMap["name"].(string)
+		if !ok || name == "" || name == "Unnamed" {
+			unnamedCount++
+			continue
+		}
+
+		network, networkOk := clusterMap["network"].(map[string]any)
+		if !networkOk {
+			continue
+		}
+
+		externalAddress, extOk := network["externalAddress"].(map[string]any)
+		if !extOk {
+			continue
+		}
+
+		ipv4, ipv4Ok := externalAddress["ipv4"].(map[string]any)
+		if !ipv4Ok {
+			continue
+		}
+
+		ip, ok := ipv4["value"].(string)
+		if !ok || ip == "" {
+			continue
+		}
+
+		clusters = append(clusters, map[string]string{
+			"name": name,
+			"ip":   ip,
+		})
+	}
+
+	return clusters, totalCount - unnamedCount, nil
+}

--- a/internal/nutanix/nutanix.go
+++ b/internal/nutanix/nutanix.go
@@ -35,13 +35,6 @@ type NutanixClient interface {
 	MakeRequest(ctx context.Context, method, action string, opts ...RequestOptions) (*http.Response, error)
 }
 
-// Cluster represents a Nutanix cluster (Prism Central OR Element).
-type Cluster struct {
-	Name string
-	URL  string `yaml:"URL"`
-	API  NutanixClient
-}
-
 // Client is a single HTTP client for either Prism Element or Prism Central.
 // The basePath field captures the URL-prefix difference between the two:
 //   - PE: "/PrismGateway/services/rest"
@@ -56,8 +49,8 @@ type Client struct {
 	isPC         bool
 	httpClient   *http.Client
 	credsMu      sync.RWMutex
-	refreshMu    sync.Mutex  // serialises refreshCreds; only one goroutine refreshes at a time
-	lastRefresh  time.Time   // others that arrive after a recent refresh skip calling it again
+	refreshMu    sync.Mutex // serialises refreshCreds; only one goroutine refreshes at a time
+	lastRefresh  time.Time  // others that arrive after a recent refresh skip calling it again
 }
 
 // RequestOptions holds optional components for a request.
@@ -65,36 +58,6 @@ type RequestOptions struct {
 	Params  url.Values
 	Payload any
 	Body    string
-}
-
-// NewCluster returns a new Nutanix Cluster, fetching credentials and constructing the API client.
-// Returns nil if credentials cannot be obtained.
-func NewCluster(name, rawURL string, ncp auth.CredentialProvider, isPC bool, skipTLSVerify bool, timeout time.Duration) *Cluster {
-	var username, password string
-	var err error
-
-	if isPC {
-		username, password, err = ncp.GetPCCreds(name)
-	} else {
-		username, password, err = ncp.GetPECreds(name)
-	}
-
-	if username == "" || password == "" {
-		kind := "Prism Element"
-		if isPC {
-			kind = "Prism Central"
-		}
-		slog.Error("Failed to get credentials", "kind", kind, "name", name, "error", err)
-		return nil
-	}
-
-	api := newClient(name, rawURL, username, password, ncp, isPC, skipTLSVerify, timeout)
-
-	return &Cluster{
-		Name: name,
-		URL:  rawURL,
-		API:  api,
-	}
 }
 
 // newClient constructs a Client. basePath is set based on whether this targets PE or PC.

--- a/internal/nutanix/nutanix.go
+++ b/internal/nutanix/nutanix.go
@@ -28,8 +28,6 @@ import (
 	"time"
 
 	"github.com/ingka-group/nutanix-exporter/internal/auth"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // NutanixClient is the interface implemented by all API clients.
@@ -39,10 +37,9 @@ type NutanixClient interface {
 
 // Cluster represents a Nutanix cluster (Prism Central OR Element).
 type Cluster struct {
-	Name     string
-	URL      string `yaml:"URL"`
-	API      NutanixClient
-	Registry *prometheus.Registry
+	Name string
+	URL  string `yaml:"URL"`
+	API  NutanixClient
 }
 
 // Client is a single HTTP client for either Prism Element or Prism Central.
@@ -94,10 +91,9 @@ func NewCluster(name, rawURL string, ncp auth.CredentialProvider, isPC bool, ski
 	api := newClient(name, rawURL, username, password, ncp, isPC, skipTLSVerify, timeout)
 
 	return &Cluster{
-		Name:     name,
-		URL:      rawURL,
-		API:      api,
-		Registry: prometheus.NewRegistry(),
+		Name: name,
+		URL:  rawURL,
+		API:  api,
 	}
 }
 

--- a/internal/nutanix/nutanix.go
+++ b/internal/nutanix/nutanix.go
@@ -32,302 +32,232 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// NutanixClient is the interface implemented by all API clients.
 type NutanixClient interface {
-	RefreshCredentials(ncp auth.CredentialProvider) error
-	CreateRequest(ctx context.Context, reqType, action string, p RequestParams) (*http.Request, error)
-	MakeRequestWithParams(ctx context.Context, reqType, action string, p RequestParams) (*http.Response, error)
-	MakeRequest(ctx context.Context, reqType, action string) (*http.Response, error)
+	MakeRequest(ctx context.Context, method, action string, opts ...RequestOptions) (*http.Response, error)
 }
 
-// Cluster represents a Nutanix cluster (Prism Central OR Element)
+// Cluster represents a Nutanix cluster (Prism Central OR Element).
 type Cluster struct {
-	Name          string
-	URL           string `yaml:"URL"`
-	API           NutanixClient
-	Registry      *prometheus.Registry
-	Collectors    []prometheus.Collector
-	RefreshNeeded bool
-	Mutex         sync.Mutex
+	Name       string
+	URL        string `yaml:"URL"`
+	API        NutanixClient
+	Registry   *prometheus.Registry
+	Collectors []prometheus.Collector
+	Mutex      sync.Mutex
 }
 
-// PEClient represents the Prism Element API client
-type PEClient struct {
-	URL           string
-	Username      string
-	Password      string
-	SkipTLSVerify bool
-	Timeout       time.Duration
+// Client is a single HTTP client for either Prism Element or Prism Central.
+// The basePath field captures the URL-prefix difference between the two:
+//   - PE: "/PrismGateway/services/rest"
+//   - PC: "" (bare path)
+type Client struct {
+	baseURL      string
+	basePath     string
+	clusterName  string // used as the key for credential lookups
+	username     string
+	password     string
+	credProvider auth.CredentialProvider
+	isPC         bool
+	httpClient   *http.Client
+	credsMu      sync.RWMutex
+	refreshMu    sync.Mutex  // serialises refreshCreds; only one goroutine refreshes at a time
+	lastRefresh  time.Time   // others that arrive after a recent refresh skip calling it again
 }
 
-// PCClient represents the Prism Central API client
-type PCClient struct {
-	URL           string
-	Username      string
-	Password      string
-	SkipTLSVerify bool
-	Timeout       time.Duration
-}
-
-// RequestParams holds the components for a request (body, header, params)
-type RequestParams struct {
-	Body    string
-	Header  string
+// RequestOptions holds optional components for a request.
+type RequestOptions struct {
 	Params  url.Values
 	Payload any
+	Body    string
 }
 
-// NewCluster returns a new Nutanix cluster object, fetching credentials and creating an API client.
-func NewCluster(name, url string, ncp auth.CredentialProvider, isPC bool, skipTLSVerify bool, timeout time.Duration) *Cluster {
-	var api NutanixClient
+// NewCluster returns a new Nutanix Cluster, fetching credentials and constructing the API client.
+// Returns nil if credentials cannot be obtained.
+func NewCluster(name, rawURL string, ncp auth.CredentialProvider, isPC bool, skipTLSVerify bool, timeout time.Duration) *Cluster {
 	var username, password string
 	var err error
 
 	if isPC {
 		username, password, err = ncp.GetPCCreds(name)
-		if username == "" || password == "" {
-			slog.Error("Failed to get credentials for Prism Central", "name", name, "error", err)
-			return nil
-		}
-		api = NewPCClient(url, username, password, skipTLSVerify, timeout)
 	} else {
 		username, password, err = ncp.GetPECreds(name)
-		if username == "" || password == "" {
-			slog.Error("Failed to get credentials for Prism Element", "name", name, "error", err)
-			return nil
-		}
-		api = NewPEClient(url, username, password, skipTLSVerify, timeout)
 	}
+
+	if username == "" || password == "" {
+		kind := "Prism Element"
+		if isPC {
+			kind = "Prism Central"
+		}
+		slog.Error("Failed to get credentials", "kind", kind, "name", name, "error", err)
+		return nil
+	}
+
+	api := newClient(name, rawURL, username, password, ncp, isPC, skipTLSVerify, timeout)
 
 	return &Cluster{
 		Name:     name,
-		URL:      url,
+		URL:      rawURL,
 		API:      api,
 		Registry: prometheus.NewRegistry(),
 	}
 }
 
-// NewPEClient returns a new Prism Element client object
-func NewPEClient(url, username, password string, skipTLSVerify bool, timeout time.Duration) *PEClient {
-	return &PEClient{
-		URL:           url,
-		Username:      username,
-		Password:      password,
-		SkipTLSVerify: skipTLSVerify,
-		Timeout:       timeout,
+// newClient constructs a Client. basePath is set based on whether this targets PE or PC.
+func newClient(clusterName, baseURL, username, password string, ncp auth.CredentialProvider, isPC bool, skipTLSVerify bool, timeout time.Duration) *Client {
+	basePath := ""
+	if !isPC {
+		basePath = "/PrismGateway/services/rest"
+	}
+
+	return &Client{
+		baseURL:      strings.TrimRight(baseURL, "/"),
+		basePath:     basePath,
+		clusterName:  clusterName,
+		username:     username,
+		password:     password,
+		credProvider: ncp,
+		isPC:         isPC,
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: skipTLSVerify}, //nolint:gosec
+			},
+			Timeout: timeout,
+		},
 	}
 }
 
-// NewPCClient returns a new Prism Central client object
-func NewPCClient(url, username, password string, skipTLSVerify bool, timeout time.Duration) *PCClient {
-	return &PCClient{
-		URL:           url,
-		Username:      username,
-		Password:      password,
-		SkipTLSVerify: skipTLSVerify,
-		Timeout:       timeout,
-	}
+// NewPEClient returns a NutanixClient targeting a Prism Element cluster.
+func NewPEClient(clusterName, rawURL, username, password string, ncp auth.CredentialProvider, skipTLSVerify bool, timeout time.Duration) NutanixClient {
+	return newClient(clusterName, rawURL, username, password, ncp, false, skipTLSVerify, timeout)
 }
 
-// Refreshes stale credentials using client methods
-func (c *Cluster) RefreshCredentialsIfNeeded(ncp auth.CredentialProvider) {
-	c.Mutex.Lock()
-	defer c.Mutex.Unlock()
-
-	if c.RefreshNeeded {
-		if err := c.API.RefreshCredentials(ncp); err != nil {
-			slog.Error("Failed to refresh credentials for cluster", "name", c.Name, "error", err)
-			return
-		}
-		c.RefreshNeeded = false // Reset the flag after refreshing
-		slog.Info("Credentials refreshed for cluster", "name", c.Name)
-	}
+// NewPCClient returns a NutanixClient targeting Prism Central.
+func NewPCClient(clusterName, rawURL, username, password string, ncp auth.CredentialProvider, skipTLSVerify bool, timeout time.Duration) NutanixClient {
+	return newClient(clusterName, rawURL, username, password, ncp, true, skipTLSVerify, timeout)
 }
 
-// RefreshCredentials refreshes the credentials for the PEClient
-func (c *PEClient) RefreshCredentials(ncp auth.CredentialProvider) error {
-	username, password, err := ncp.GetPECreds(c.URL)
-	if username == "" || password == "" {
-		return fmt.Errorf("failed to refresh credentials for PE client %s: %v", c.URL, err)
-	}
-	c.Username = username
-	c.Password = password
-	return nil
-}
+// buildRequest constructs an HTTP request from method, action path, and optional opts.
+func (c *Client) buildRequest(ctx context.Context, method, action string, opt RequestOptions) (*http.Request, error) {
+	rawURL := fmt.Sprintf("%s%s/%s", c.baseURL, c.basePath, strings.Trim(action, "/"))
 
-// RefreshCredentials refreshes the credentials for the PCClient
-func (c *PCClient) RefreshCredentials(ncp auth.CredentialProvider) error {
-	username, password, err := ncp.GetPCCreds(c.URL)
-	if username == "" || password == "" {
-		return fmt.Errorf("failed to refresh credentials for PC client %s: %v", c.URL, err)
-	}
-	c.Username = username
-	c.Password = password
-	return nil
-}
-
-// CreateRequest takes context, request type, action, and request parameters
-// Returns a new HTTP request for PEClient
-func (c *PEClient) CreateRequest(ctx context.Context, reqType, action string, p RequestParams) (*http.Request, error) {
-	baseURL := fmt.Sprintf("%s/PrismGateway/services/rest/%s/", strings.Trim(c.URL, "/"), strings.Trim(action, "/"))
-
-	// Parse the base URL to add query parameters
-	parsedURL, err := url.Parse(baseURL)
+	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
 	}
 
-	// Add query parameters if they exist
-	if p.Params != nil {
-		// Merge existing query parameters with new ones
-		query := parsedURL.Query()
-		for key, values := range p.Params {
-			for _, value := range values {
-				query.Add(key, value)
+	if opt.Params != nil {
+		q := parsedURL.Query()
+		for key, values := range opt.Params {
+			for _, v := range values {
+				q.Add(key, v)
 			}
 		}
-		parsedURL.RawQuery = query.Encode()
+		parsedURL.RawQuery = q.Encode()
 	}
 
 	fullURL := parsedURL.String()
-
-	slog.Info("Sending request to", "url", fullURL, "action", action, "reqType", reqType)
+	slog.Info("Sending request", "url", fullURL, "method", method)
 
 	var req *http.Request
-
-	// Check if the payload is not nil and marshal it to JSON if needed
-	if p.Payload != nil {
-		jsonPayload, err := json.Marshal(p.Payload)
+	if opt.Payload != nil {
+		jsonPayload, err := json.Marshal(opt.Payload)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal payload: %w", err)
 		}
-		req, err = http.NewRequestWithContext(ctx, reqType, fullURL, strings.NewReader(string(jsonPayload)))
+		req, err = http.NewRequestWithContext(ctx, method, fullURL, strings.NewReader(string(jsonPayload)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/json")
 	} else {
-		// Use the old method with body as string if no payload is provided
-		req, err = http.NewRequestWithContext(ctx, reqType, fullURL, strings.NewReader(p.Body))
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.SetBasicAuth(c.Username, c.Password)
-	return req, nil
-}
-
-// CreateRequest takes context, request type, action and request parameters
-// Returns a new http request for PCClient
-func (c *PCClient) CreateRequest(ctx context.Context, reqType, action string, p RequestParams) (*http.Request, error) {
-	// Build the base URL
-	baseURL := fmt.Sprintf("%s/%s", strings.Trim(c.URL, "/"), strings.Trim(action, "/"))
-
-	// Parse the base URL to add query parameters
-	parsedURL, err := url.Parse(baseURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL: %w", err)
-	}
-
-	// Add query parameters if they exist
-	if p.Params != nil {
-		// Merge existing query parameters with new ones
-		query := parsedURL.Query()
-		for key, values := range p.Params {
-			for _, value := range values {
-				query.Add(key, value)
-			}
-		}
-		parsedURL.RawQuery = query.Encode()
-	}
-
-	fullURL := parsedURL.String()
-
-	slog.Info("Sending request to", "url", fullURL, "action", action, "reqType", reqType)
-
-	var req *http.Request
-
-	// Check if the payload is not nil and marshal it to JSON if needed
-	if p.Payload != nil {
-		jsonPayload, err := json.Marshal(p.Payload)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal payload: %w", err)
-		}
-		req, err = http.NewRequestWithContext(ctx, reqType, fullURL, strings.NewReader(string(jsonPayload)))
+		req, err = http.NewRequestWithContext(ctx, method, fullURL, strings.NewReader(opt.Body))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
-		req.Header.Set("Content-Type", "application/json")
-	} else {
-		// Use the old method with body as string if no payload is provided
-		req, err = http.NewRequestWithContext(ctx, reqType, fullURL, strings.NewReader(p.Body))
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
+	c.credsMu.RLock()
+	req.SetBasicAuth(c.username, c.password)
+	c.credsMu.RUnlock()
 
-	req.SetBasicAuth(c.Username, c.Password)
 	return req, nil
 }
 
-// MakeRequestWithParams takes context, request type, action, and request parameters
-// Returns a new http response for PEClient
-func (c *PEClient) MakeRequestWithParams(ctx context.Context, reqType, action string, p RequestParams) (*http.Response, error) {
-	req, err := c.CreateRequest(ctx, reqType, action, p)
+// MakeRequest executes a request with optional RequestOptions. On a 401/403 it refreshes
+// all credentials and retries once.
+func (c *Client) MakeRequest(ctx context.Context, method, action string, opts ...RequestOptions) (*http.Response, error) {
+	var opt RequestOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	req, err := c.buildRequest(ctx, method, action, opt)
 	if err != nil {
 		return nil, err
 	}
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: c.SkipTLSVerify},
-		},
-		Timeout: c.Timeout,
-	}
-
-	resp, err := client.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
 
-	return resp, nil
-}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		_ = resp.Body.Close()
 
-// MakeRequestWithParams takes context, request type, action and request parameters
-// Returns a new http response for PCClient
-func (c *PCClient) MakeRequestWithParams(ctx context.Context, reqType, action string, p RequestParams) (*http.Response, error) {
-	req, err := c.CreateRequest(ctx, reqType, action, p)
-	if err != nil {
-		return nil, err
-	}
+		slog.Warn("Authentication failed, refreshing credentials and retrying", "url", req.URL.String())
+		if refreshErr := c.refreshCreds(); refreshErr != nil {
+			return nil, fmt.Errorf("credential refresh failed: %w", refreshErr)
+		}
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: c.SkipTLSVerify},
-		},
-		Timeout: c.Timeout,
-	}
+		retryReq, err := c.buildRequest(ctx, method, action, opt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build retry request: %w", err)
+		}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("%w", err)
+		resp, err = c.httpClient.Do(retryReq)
+		if err != nil {
+			return nil, fmt.Errorf("retry request failed: %w", err)
+		}
 	}
 
 	return resp, nil
 }
 
-// MakeRequest takes context, request type, and action
-// Returns a new http response
-// Calls MakeRequestWithParams with empty RequestParams for PEClient
-func (c *PEClient) MakeRequest(ctx context.Context, reqType, action string) (*http.Response, error) {
-	return c.MakeRequestWithParams(ctx, reqType, action, RequestParams{})
-}
+// refreshCreds refreshes credentials at most once per second. Concurrent callers block on
+// refreshMu; if a refresh just completed by the time they acquire the lock they return
+// immediately, picking up the credentials the first caller already fetched.
+func (c *Client) refreshCreds() error {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
 
-// MakeRequest takes context, request type, and action
-// Returns a new http response
-// Calls MakeRequestWithParams with empty RequestParams for PCClient
-func (c *PCClient) MakeRequest(ctx context.Context, reqType, action string) (*http.Response, error) {
-	return c.MakeRequestWithParams(ctx, reqType, action, RequestParams{})
+	// If another goroutine already refreshed within the last second, skip.
+	if time.Since(c.lastRefresh) < time.Second {
+		return nil
+	}
+
+	if err := c.credProvider.Refresh(); err != nil {
+		return fmt.Errorf("provider refresh failed: %w", err)
+	}
+
+	var username, password string
+	var err error
+
+	if c.isPC {
+		username, password, err = c.credProvider.GetPCCreds(c.clusterName)
+	} else {
+		username, password, err = c.credProvider.GetPECreds(c.clusterName)
+	}
+
+	if username == "" || password == "" {
+		return fmt.Errorf("empty credentials after refresh: %w", err)
+	}
+
+	c.credsMu.Lock()
+	c.username = username
+	c.password = password
+	c.credsMu.Unlock()
+
+	c.lastRefresh = time.Now()
+	return nil
 }

--- a/internal/nutanix/nutanix.go
+++ b/internal/nutanix/nutanix.go
@@ -39,12 +39,10 @@ type NutanixClient interface {
 
 // Cluster represents a Nutanix cluster (Prism Central OR Element).
 type Cluster struct {
-	Name       string
-	URL        string `yaml:"URL"`
-	API        NutanixClient
-	Registry   *prometheus.Registry
-	Collectors []prometheus.Collector
-	Mutex      sync.Mutex
+	Name     string
+	URL      string `yaml:"URL"`
+	API      NutanixClient
+	Registry *prometheus.Registry
 }
 
 // Client is a single HTTP client for either Prism Element or Prism Central.

--- a/internal/prom/exporter.go
+++ b/internal/prom/exporter.go
@@ -54,9 +54,8 @@ func NewExporter(cluster *nutanix.Cluster, labels []string) *Exporter {
 	}
 }
 
-// valueToFloat64 converts given value to Float64
-// If the value is a string, it will be checked for "on" and "off" and converted to 1 and 0 respectively
-// Otherwise it will be parsed as a float64
+// valueToFloat64 converts a value to float64. Strings "on"/"off" (case-insensitive)
+// map to 1/0; other strings are parsed as floats.
 func (e *Exporter) valueToFloat64(value any) float64 {
 	switch v := value.(type) {
 	case float64:
@@ -64,15 +63,16 @@ func (e *Exporter) valueToFloat64(value any) float64 {
 	case bool:
 		if v {
 			return 1.0
-		} else {
+		}
+		return 0.0
+	case string:
+		if strings.EqualFold(v, "on") {
+			return 1.0
+		}
+		if strings.EqualFold(v, "off") {
 			return 0.0
 		}
-	case string:
-		if v == "on" {
-			return 1.0
-		} else if v == "off" || v == "OFF" {
-			return 0.0
-		} else if f, err := strconv.ParseFloat(v, 64); err == nil {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
 			return f
 		}
 	}

--- a/internal/prom/exporter.go
+++ b/internal/prom/exporter.go
@@ -111,13 +111,8 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
-// fetchData makes a GET request to the given path and returns the response body a map[string]any. It also handles credential refresh logic in case of authentication errors.
+// fetchData makes a GET request to the given path and returns the response body as a map[string]any.
 func (e *Exporter) fetchData(ctx context.Context, path string) (result map[string]any, err error) {
-
-	if e.Cluster.RefreshNeeded {
-		return nil, fmt.Errorf("skipping %s due to known stale creds", e.Cluster.Name)
-	}
-
 	resp, err := e.Cluster.API.MakeRequest(ctx, "GET", path)
 	if err != nil {
 		return nil, err
@@ -128,15 +123,7 @@ func (e *Exporter) fetchData(ctx context.Context, path string) (result map[strin
 		}
 	}()
 
-	if resp.StatusCode == 403 || resp.StatusCode == 401 {
-		e.Cluster.Mutex.Lock()
-		if !e.Cluster.RefreshNeeded {
-			slog.Warn("Marking stale credentials for refresh", "cluster", e.Cluster.Name)
-			e.Cluster.RefreshNeeded = true
-		}
-		e.Cluster.Mutex.Unlock()
-		return nil, fmt.Errorf("authentication failed for cluster %s", e.Cluster.Name)
-	} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("request failed: %s", resp.Status)
 	}
 

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -92,7 +92,6 @@ func (es *ExporterService) GetHandler() http.Handler {
 		es.clustersMu.RLock()
 		gatherers := make(prometheus.Gatherers, 0, len(es.clustersMap))
 		for _, cluster := range es.clustersMap {
-			cluster.RefreshCredentialsIfNeeded(es.credentialProvider)
 			gatherers = append(gatherers, cluster.Registry)
 		}
 		es.clustersMu.RUnlock()
@@ -364,18 +363,17 @@ func (es *ExporterService) fetchClusters() (map[string]string, error) {
 
 // API request methods
 func (es *ExporterService) makeV3Request(ctx context.Context, page int) (*http.Response, error) {
-	payload := map[string]any{
-		"kind":   "cluster",
-		"length": 100,
-		"offset": page * 100,
-	}
-	return es.pcCluster.API.MakeRequestWithParams(ctx, "POST", "/api/nutanix/v3/clusters/list", nutanix.RequestParams{
-		Payload: payload,
+	return es.pcCluster.API.MakeRequest(ctx, "POST", "/api/nutanix/v3/clusters/list", nutanix.RequestOptions{
+		Payload: map[string]any{
+			"kind":   "cluster",
+			"length": 100,
+			"offset": page * 100,
+		},
 	})
 }
 
 func (es *ExporterService) makeV4Request(ctx context.Context, page int) (*http.Response, error) {
-	return es.pcCluster.API.MakeRequestWithParams(ctx, "GET", "/api/clustermgmt/v4.0/config/clusters", nutanix.RequestParams{
+	return es.pcCluster.API.MakeRequest(ctx, "GET", "/api/clustermgmt/v4.0/config/clusters", nutanix.RequestOptions{
 		Params: url.Values{
 			"$limit":   []string{"100"},
 			"$page":    []string{fmt.Sprintf("%d", page)},
@@ -385,7 +383,7 @@ func (es *ExporterService) makeV4Request(ctx context.Context, page int) (*http.R
 }
 
 func (es *ExporterService) makeV4b1Request(ctx context.Context, page int) (*http.Response, error) {
-	return es.pcCluster.API.MakeRequestWithParams(ctx, "GET", "/api/clustermgmt/v4.0.b1/config/clusters", nutanix.RequestParams{
+	return es.pcCluster.API.MakeRequest(ctx, "GET", "/api/clustermgmt/v4.0.b1/config/clusters", nutanix.RequestOptions{
 		Params: url.Values{
 			"$limit":   []string{"100"},
 			"$page":    []string{fmt.Sprintf("%d", page)},
@@ -514,9 +512,6 @@ func (es *ExporterService) metricsHandler(w http.ResponseWriter, r *http.Request
 		http.NotFound(w, r)
 		return
 	}
-
-	// Refresh credentials for the specific cluster
-	cluster.RefreshCredentialsIfNeeded(es.credentialProvider)
 
 	// Serve metrics from the specific cluster's registry
 	promhttp.HandlerFor(cluster.Registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -61,23 +61,23 @@ func NewExporterService(cfg *config.Config, credProvider auth.CredentialProvider
 	}
 }
 
-func (es *ExporterService) Start() error {
-	return es.StartWithServer(true)
+func (es *ExporterService) Start(ctx context.Context) error {
+	return es.StartWithServer(ctx, true)
 }
 
-func (es *ExporterService) StartWithServer(startHTTPServer bool) error {
+func (es *ExporterService) StartWithServer(ctx context.Context, startHTTPServer bool) error {
 	// Initialize Prism Central connection
 	if err := es.initializePrismCentral(); err != nil {
 		return fmt.Errorf("failed to initialize Prism Central: %w", err)
 	}
 
 	// Initialize clusters
-	if err := es.refreshClusters(); err != nil {
+	if err := es.refreshClusters(ctx); err != nil {
 		return fmt.Errorf("failed to initialize clusters: %w", err)
 	}
 
 	// Start refresh goroutines
-	es.startRefreshRoutines()
+	es.startRefreshRoutines(ctx)
 
 	if startHTTPServer {
 		// Setup HTTP server
@@ -136,18 +136,23 @@ func (es *ExporterService) initializePrismCentral() error {
 	return nil
 }
 
-func (es *ExporterService) startRefreshRoutines() {
+func (es *ExporterService) startRefreshRoutines(ctx context.Context) {
 	// Credential refresh
 	if es.config.VaultRefreshInterval > 0 {
 		go func() {
 			ticker := time.NewTicker(es.config.VaultRefreshInterval)
 			defer ticker.Stop()
-			for range ticker.C {
-				slog.Info("Refreshing credentials...")
-				if err := es.credentialProvider.Refresh(); err != nil {
-					slog.Error("Failed to refresh credentials", "error", err)
-				} else {
-					slog.Info("Credentials refreshed successfully")
+			for {
+				select {
+				case <-ticker.C:
+					slog.Info("Refreshing credentials...")
+					if err := es.credentialProvider.Refresh(); err != nil {
+						slog.Error("Failed to refresh credentials", "error", err)
+					} else {
+						slog.Info("Credentials refreshed successfully")
+					}
+				case <-ctx.Done():
+					return
 				}
 			}
 		}()
@@ -158,20 +163,25 @@ func (es *ExporterService) startRefreshRoutines() {
 		go func() {
 			ticker := time.NewTicker(es.config.ClusterRefreshInterval)
 			defer ticker.Stop()
-			for range ticker.C {
-				slog.Info("Refreshing cluster list...")
-				if err := es.refreshClusters(); err != nil {
-					slog.Error("Failed to refresh clusters", "error", err)
-				} else {
-					slog.Info("Cluster list refreshed successfully")
+			for {
+				select {
+				case <-ticker.C:
+					slog.Info("Refreshing cluster list...")
+					if err := es.refreshClusters(ctx); err != nil {
+						slog.Error("Failed to refresh clusters", "error", err)
+					} else {
+						slog.Info("Cluster list refreshed successfully")
+					}
+				case <-ctx.Done():
+					return
 				}
 			}
 		}()
 	}
 }
 
-func (es *ExporterService) refreshClusters() error {
-	clusterData, err := es.fetchClusters()
+func (es *ExporterService) refreshClusters(ctx context.Context) error {
+	clusterData, err := es.fetchClusters(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to fetch clusters: %w", err)
 	}
@@ -236,8 +246,8 @@ func (es *ExporterService) refreshClusters() error {
 	return nil
 }
 
-func (es *ExporterService) fetchClusters() (map[string]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+func (es *ExporterService) fetchClusters(ctx context.Context) (map[string]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
 	clusterData := make(map[string]string)

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -29,17 +29,25 @@ import (
 	"github.com/ingka-group/nutanix-exporter/internal/auth"
 	"github.com/ingka-group/nutanix-exporter/internal/config"
 	"github.com/ingka-group/nutanix-exporter/internal/nutanix"
-	"github.com/ingka-group/nutanix-exporter/internal/prom"
+	"github.com/ingka-group/nutanix-exporter/internal/collector"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const ListenAddress = ":9408"
 
+// clusterEntry pairs a Nutanix cluster with its dedicated Prometheus registry.
+// Keeping the registry here rather than on nutanix.Cluster means the HTTP client
+// layer has no Prometheus dependency.
+type clusterEntry struct {
+	cluster  *nutanix.Cluster
+	registry *prometheus.Registry
+}
+
 type ExporterService struct {
 	config             *config.Config
 	credentialProvider auth.CredentialProvider
-	clustersMap        map[string]*nutanix.Cluster
+	clustersMap        map[string]*clusterEntry
 	clustersMu         sync.RWMutex
 	server             *http.Server
 	pcCluster          *nutanix.Cluster
@@ -49,7 +57,7 @@ func NewExporterService(cfg *config.Config, credProvider auth.CredentialProvider
 	return &ExporterService{
 		config:             cfg,
 		credentialProvider: credProvider,
-		clustersMap:        make(map[string]*nutanix.Cluster),
+		clustersMap:        make(map[string]*clusterEntry),
 	}
 }
 
@@ -92,7 +100,7 @@ func (es *ExporterService) GetHandler() http.Handler {
 		es.clustersMu.RLock()
 		gatherers := make(prometheus.Gatherers, 0, len(es.clustersMap))
 		for _, cluster := range es.clustersMap {
-			gatherers = append(gatherers, cluster.Registry)
+			gatherers = append(gatherers, cluster.registry)
 		}
 		es.clustersMu.RUnlock()
 		promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{}).ServeHTTP(w, r)
@@ -168,7 +176,7 @@ func (es *ExporterService) refreshClusters() error {
 		return fmt.Errorf("failed to fetch clusters: %w", err)
 	}
 
-	newClustersMap := make(map[string]*nutanix.Cluster)
+	newClustersMap := make(map[string]*clusterEntry)
 	for name, url := range clusterData {
 		cluster := nutanix.NewCluster(
 			name,
@@ -184,38 +192,39 @@ func (es *ExporterService) refreshClusters() error {
 			continue
 		}
 
-		// Register collectors for this cluster
+		registry := prometheus.NewRegistry()
+
 		slog.Info("Registering collectors for cluster", "name", name)
-		scCollector, err := prom.NewStorageContainerCollector(cluster, es.config.ConfigPath+"/storage_container.yaml")
+		scCollector, err := collector.NewStorageContainerCollector(cluster, es.config.ConfigPath+"/storage_container.yaml")
 		if err != nil {
 			slog.Error("Failed to init storage container collector", "cluster", name, "error", err)
 			continue
 		}
-		clusterCollector, err := prom.NewClusterCollector(cluster, es.config.ConfigPath+"/cluster.yaml")
+		clusterCollector, err := collector.NewClusterCollector(cluster, es.config.ConfigPath+"/cluster.yaml")
 		if err != nil {
 			slog.Error("Failed to init cluster collector", "cluster", name, "error", err)
 			continue
 		}
-		hostCollector, err := prom.NewHostCollector(cluster, es.config.ConfigPath+"/host.yaml")
+		hostCollector, err := collector.NewHostCollector(cluster, es.config.ConfigPath+"/host.yaml")
 		if err != nil {
 			slog.Error("Failed to init host collector", "cluster", name, "error", err)
 			continue
 		}
-		vmCollector, err := prom.NewVMCollector(cluster, es.config.ConfigPath+"/vm.yaml")
+		vmCollector, err := collector.NewVMCollector(cluster, es.config.ConfigPath+"/vm.yaml")
 		if err != nil {
 			slog.Error("Failed to init VM collector", "cluster", name, "error", err)
 			continue
 		}
-		vmv1Collector, err := prom.NewVMv1Collector(cluster, es.config.ConfigPath+"/vm_v1.yaml")
+		vmv1Collector, err := collector.NewVMv1Collector(cluster, es.config.ConfigPath+"/vm_v1.yaml")
 		if err != nil {
 			slog.Error("Failed to init VM v1 collector", "cluster", name, "error", err)
 			continue
 		}
 		for _, collector := range []prometheus.Collector{scCollector, clusterCollector, hostCollector, vmCollector, vmv1Collector} {
-			cluster.Registry.MustRegister(collector)
+			registry.MustRegister(collector)
 		}
 
-		newClustersMap[name] = cluster
+		newClustersMap[name] = &clusterEntry{cluster: cluster, registry: registry}
 	}
 
 	// Update the clusters map atomically
@@ -537,5 +546,5 @@ func (es *ExporterService) metricsHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	// Serve metrics from the specific cluster's registry
-	promhttp.HandlerFor(cluster.Registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+	promhttp.HandlerFor(cluster.registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
 }

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -396,16 +396,31 @@ func (es *ExporterService) parseV3Clusters(result map[string]any) ([]map[string]
 		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'entities' field")
 	}
 
-	// Extract total count from metadata
-	metadata := result["metadata"].(map[string]any)
-	totalCount := int(metadata["total_matches"].(float64))
+	metadata, ok := result["metadata"].(map[string]any)
+	if !ok {
+		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'metadata' field")
+	}
+	totalMatches, ok := metadata["total_matches"].(float64)
+	if !ok {
+		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'total_matches' field")
+	}
+	totalCount := int(totalMatches)
 
 	var clusters []map[string]string
 	unnamedCount := 0
 	for _, entity := range entities {
-		cluster := entity.(map[string]any)
-		spec := cluster["spec"].(map[string]any)
-		status := cluster["status"].(map[string]any)
+		cluster, ok := entity.(map[string]any)
+		if !ok {
+			continue
+		}
+		spec, ok := cluster["spec"].(map[string]any)
+		if !ok {
+			continue
+		}
+		status, ok := cluster["status"].(map[string]any)
+		if !ok {
+			continue
+		}
 
 		name, ok := spec["name"].(string)
 		if !ok || name == "" || name == "Unnamed" {
@@ -413,8 +428,14 @@ func (es *ExporterService) parseV3Clusters(result map[string]any) ([]map[string]
 			continue
 		}
 
-		resources := status["resources"].(map[string]any)
-		network := resources["network"].(map[string]any)
+		resources, ok := status["resources"].(map[string]any)
+		if !ok {
+			continue
+		}
+		network, ok := resources["network"].(map[string]any)
+		if !ok {
+			continue
+		}
 		ip, ok := network["external_ip"].(string)
 		if !ok || ip == "" {
 			continue
@@ -426,7 +447,6 @@ func (es *ExporterService) parseV3Clusters(result map[string]any) ([]map[string]
 		})
 	}
 
-	// Adjust total count to exclude unnamed clusters
 	return clusters, totalCount - unnamedCount, nil
 }
 
@@ -436,9 +456,15 @@ func (es *ExporterService) parseV4Clusters(result map[string]any) ([]map[string]
 		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'data' field")
 	}
 
-	// Extract total count from metadata
-	metadata := result["metadata"].(map[string]any)
-	totalCount := int(metadata["totalAvailableResults"].(float64))
+	metadata, ok := result["metadata"].(map[string]any)
+	if !ok {
+		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'metadata' field")
+	}
+	totalAvailable, ok := metadata["totalAvailableResults"].(float64)
+	if !ok {
+		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'totalAvailableResults' field")
+	}
+	totalCount := int(totalAvailable)
 
 	var clusters []map[string]string
 	unnamedCount := 0

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -527,8 +527,11 @@ func (es *ExporterService) setupHTTPHandlers() {
 	mux.HandleFunc("/metrics/", es.metricsHandler)
 
 	es.server = &http.Server{
-		Addr:    ListenAddress,
-		Handler: mux,
+		Addr:         ListenAddress,
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 }
 

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -195,27 +195,27 @@ func (es *ExporterService) refreshClusters() error {
 		registry := prometheus.NewRegistry()
 
 		slog.Info("Registering collectors for cluster", "name", name)
-		scCollector, err := collector.NewStorageContainerCollector(cluster, es.config.ConfigPath+"/storage_container.yaml")
+		scCollector, err := collector.NewStorageContainerCollector(cluster.Name, cluster.API, es.config.ConfigPath+"/storage_container.yaml")
 		if err != nil {
 			slog.Error("Failed to init storage container collector", "cluster", name, "error", err)
 			continue
 		}
-		clusterCollector, err := collector.NewClusterCollector(cluster, es.config.ConfigPath+"/cluster.yaml")
+		clusterCollector, err := collector.NewClusterCollector(cluster.Name, cluster.API, es.config.ConfigPath+"/cluster.yaml")
 		if err != nil {
 			slog.Error("Failed to init cluster collector", "cluster", name, "error", err)
 			continue
 		}
-		hostCollector, err := collector.NewHostCollector(cluster, es.config.ConfigPath+"/host.yaml")
+		hostCollector, err := collector.NewHostCollector(cluster.Name, cluster.API, es.config.ConfigPath+"/host.yaml")
 		if err != nil {
 			slog.Error("Failed to init host collector", "cluster", name, "error", err)
 			continue
 		}
-		vmCollector, err := collector.NewVMCollector(cluster, es.config.ConfigPath+"/vm.yaml")
+		vmCollector, err := collector.NewVMCollector(cluster.Name, cluster.API, es.config.ConfigPath+"/vm.yaml")
 		if err != nil {
 			slog.Error("Failed to init VM collector", "cluster", name, "error", err)
 			continue
 		}
-		vmv1Collector, err := collector.NewVMv1Collector(cluster, es.config.ConfigPath+"/vm_v1.yaml")
+		vmv1Collector, err := collector.NewVMv1Collector(cluster.Name, cluster.API, es.config.ConfigPath+"/vm_v1.yaml")
 		if err != nil {
 			slog.Error("Failed to init VM v1 collector", "cluster", name, "error", err)
 			continue

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -211,12 +211,9 @@ func (es *ExporterService) refreshClusters() error {
 			slog.Error("Failed to init VM v1 collector", "cluster", name, "error", err)
 			continue
 		}
-		collectors := []prometheus.Collector{scCollector, clusterCollector, hostCollector, vmCollector, vmv1Collector}
-
-		for _, collector := range collectors {
+		for _, collector := range []prometheus.Collector{scCollector, clusterCollector, hostCollector, vmCollector, vmv1Collector} {
 			cluster.Registry.MustRegister(collector)
 		}
-		cluster.Collectors = collectors
 
 		newClustersMap[name] = cluster
 	}

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -478,7 +478,10 @@ func (es *ExporterService) parseV4Clusters(result map[string]any) ([]map[string]
 	var clusters []map[string]string
 	unnamedCount := 0
 	for _, item := range data {
-		clusterMap := item.(map[string]any)
+		clusterMap, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
 
 		name, ok := clusterMap["name"].(string)
 		if !ok || name == "" || name == "Unnamed" {

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -17,19 +17,17 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/ingka-group/nutanix-exporter/internal/auth"
+	"github.com/ingka-group/nutanix-exporter/internal/collector"
 	"github.com/ingka-group/nutanix-exporter/internal/config"
 	"github.com/ingka-group/nutanix-exporter/internal/nutanix"
-	"github.com/ingka-group/nutanix-exporter/internal/collector"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -181,7 +179,7 @@ func (es *ExporterService) startRefreshRoutines(ctx context.Context) {
 }
 
 func (es *ExporterService) refreshClusters(ctx context.Context) error {
-	clusterData, err := es.fetchClusters(ctx)
+	clusterData, err := nutanix.FetchClusters(ctx, es.pcCluster.API, es.config.PCAPIVersion, es.config.ClusterPrefix)
 	if err != nil {
 		return fmt.Errorf("failed to fetch clusters: %w", err)
 	}
@@ -244,290 +242,6 @@ func (es *ExporterService) refreshClusters(ctx context.Context) error {
 
 	slog.Info("Clusters refreshed", "count", len(newClustersMap))
 	return nil
-}
-
-func (es *ExporterService) fetchClusters(ctx context.Context) (map[string]string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
-
-	clusterData := make(map[string]string)
-
-	// Determine API version
-	apiVersion := es.config.PCAPIVersion
-
-	slog.Info("Fetching clusters", "api_version", apiVersion)
-
-	// Select appropriate request and parse functions based on API version
-	var makeRequest func(context.Context, int) (*http.Response, error)
-	var parseClusters func(map[string]any) ([]map[string]string, int, error)
-
-	switch apiVersion {
-	case "v3":
-		makeRequest = es.makeV3Request
-		parseClusters = es.parseV3Clusters
-	case "v4b1":
-		makeRequest = es.makeV4b1Request
-		parseClusters = es.parseV4Clusters
-	default: // v4
-		makeRequest = es.makeV4Request
-		parseClusters = es.parseV4Clusters
-	}
-
-	// Paginate through all results
-	page := 0
-	totalExpected := 0
-	totalFetched := 0
-
-	for {
-		slog.Info("Fetching clusters page", "page", page)
-
-		resp, err := makeRequest(ctx, page)
-		if err != nil {
-			return nil, fmt.Errorf("failed to make API request for page %d: %w", page, err)
-		}
-
-		var result map[string]any
-		decodeErr := func() (err error) {
-			defer func() {
-				if cerr := resp.Body.Close(); cerr != nil && err == nil {
-					err = cerr
-				}
-			}()
-			return json.NewDecoder(resp.Body).Decode(&result)
-		}()
-		if decodeErr != nil {
-			return nil, fmt.Errorf("failed to decode response for page %d: %w", page, decodeErr)
-		}
-
-		clusters, total, err := parseClusters(result)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse clusters for page %d: %w", page, err)
-		}
-
-		// Set total expected on first page
-		if page == 0 {
-			totalExpected = total
-			slog.Info("Total clusters available", "total", totalExpected)
-		}
-
-		// Process clusters from this page
-		pageClusterCount := 0
-		duplicateCount := 0
-		for _, cluster := range clusters {
-			name := cluster["name"]
-			ip := cluster["ip"]
-
-			// Skip clusters that don't match the prefix if provided
-			if es.config.ClusterPrefix != "" && !strings.HasPrefix(name, es.config.ClusterPrefix) {
-				slog.Info("Skipping cluster due to prefix filter", "name", name, "prefix", es.config.ClusterPrefix)
-				continue
-			}
-
-			// Check if we've already seen this cluster (handles duplicate results)
-			if _, exists := clusterData[name]; exists {
-				duplicateCount++
-				slog.Info("Skipping duplicate cluster", "name", name)
-				continue
-			}
-
-			clusterData[name] = fmt.Sprintf("https://%s:9440", ip)
-			slog.Info("Found cluster", "name", name, "url", clusterData[name])
-			pageClusterCount++
-		}
-
-		totalFetched += len(clusters)
-
-		slog.Info("Processed clusters from page",
-			"page", page,
-			"clusters_on_page", len(clusters),
-			"new_clusters", pageClusterCount,
-			"duplicates", duplicateCount,
-			"total_fetched", totalFetched,
-			"total_unique", len(clusterData))
-
-		// If all clusters on this page were duplicates, we're done
-		if duplicateCount == len(clusters) && len(clusters) > 0 {
-			slog.Info("All clusters on page were duplicates, stopping pagination", "page", page)
-			break
-		}
-
-		// Check if we've fetched enough pages based on the limit
-		// For v4 API: if we got less than 100 results, this is the last page
-		if len(clusters) < 100 {
-			slog.Info("Received partial page, stopping pagination",
-				"page", page,
-				"clusters_on_page", len(clusters))
-			break
-		}
-
-		// Move to next page
-		page++
-
-		// Safety check to prevent infinite loops
-		if page > 49 {
-			slog.Warn("Reached maximum page limit, stopping pagination", "max_pages", 50)
-			break
-		}
-	}
-
-	slog.Info("Completed fetching all clusters",
-		"total_api_reported", totalExpected,
-		"total_clusters_fetched", totalFetched,
-		"total_unique_clusters", len(clusterData))
-	return clusterData, nil
-}
-
-// API request methods
-func (es *ExporterService) makeV3Request(ctx context.Context, page int) (*http.Response, error) {
-	return es.pcCluster.API.MakeRequest(ctx, "POST", "/api/nutanix/v3/clusters/list", nutanix.RequestOptions{
-		Payload: map[string]any{
-			"kind":   "cluster",
-			"length": 100,
-			"offset": page * 100,
-		},
-	})
-}
-
-func (es *ExporterService) makeV4Request(ctx context.Context, page int) (*http.Response, error) {
-	return es.pcCluster.API.MakeRequest(ctx, "GET", "/api/clustermgmt/v4.0/config/clusters", nutanix.RequestOptions{
-		Params: url.Values{
-			"$limit":   []string{"100"},
-			"$page":    []string{fmt.Sprintf("%d", page)},
-			"$orderby": []string{"name"},
-		},
-	})
-}
-
-func (es *ExporterService) makeV4b1Request(ctx context.Context, page int) (*http.Response, error) {
-	return es.pcCluster.API.MakeRequest(ctx, "GET", "/api/clustermgmt/v4.0.b1/config/clusters", nutanix.RequestOptions{
-		Params: url.Values{
-			"$limit":   []string{"100"},
-			"$page":    []string{fmt.Sprintf("%d", page)},
-			"$orderby": []string{"name"},
-		},
-	})
-}
-
-// Parsing methods with metadata extraction
-func (es *ExporterService) parseV3Clusters(result map[string]any) ([]map[string]string, int, error) {
-	entities, ok := result["entities"].([]any)
-	if !ok {
-		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'entities' field")
-	}
-
-	metadata, ok := result["metadata"].(map[string]any)
-	if !ok {
-		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'metadata' field")
-	}
-	totalMatches, ok := metadata["total_matches"].(float64)
-	if !ok {
-		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'total_matches' field")
-	}
-	totalCount := int(totalMatches)
-
-	var clusters []map[string]string
-	unnamedCount := 0
-	for _, entity := range entities {
-		cluster, ok := entity.(map[string]any)
-		if !ok {
-			continue
-		}
-		spec, ok := cluster["spec"].(map[string]any)
-		if !ok {
-			continue
-		}
-		status, ok := cluster["status"].(map[string]any)
-		if !ok {
-			continue
-		}
-
-		name, ok := spec["name"].(string)
-		if !ok || name == "" || name == "Unnamed" {
-			unnamedCount++
-			continue
-		}
-
-		resources, ok := status["resources"].(map[string]any)
-		if !ok {
-			continue
-		}
-		network, ok := resources["network"].(map[string]any)
-		if !ok {
-			continue
-		}
-		ip, ok := network["external_ip"].(string)
-		if !ok || ip == "" {
-			continue
-		}
-
-		clusters = append(clusters, map[string]string{
-			"name": name,
-			"ip":   ip,
-		})
-	}
-
-	return clusters, totalCount - unnamedCount, nil
-}
-
-func (es *ExporterService) parseV4Clusters(result map[string]any) ([]map[string]string, int, error) {
-	data, ok := result["data"].([]any)
-	if !ok {
-		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'data' field")
-	}
-
-	metadata, ok := result["metadata"].(map[string]any)
-	if !ok {
-		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'metadata' field")
-	}
-	totalAvailable, ok := metadata["totalAvailableResults"].(float64)
-	if !ok {
-		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'totalAvailableResults' field")
-	}
-	totalCount := int(totalAvailable)
-
-	var clusters []map[string]string
-	unnamedCount := 0
-	for _, item := range data {
-		clusterMap, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		name, ok := clusterMap["name"].(string)
-		if !ok || name == "" || name == "Unnamed" {
-			unnamedCount++
-			continue
-		}
-
-		// Navigate to network.externalAddress.ipv4.value
-		network, networkOk := clusterMap["network"].(map[string]any)
-		if !networkOk {
-			continue
-		}
-
-		externalAddress, extOk := network["externalAddress"].(map[string]any)
-		if !extOk {
-			continue
-		}
-
-		ipv4, ipv4Ok := externalAddress["ipv4"].(map[string]any)
-		if !ipv4Ok {
-			continue
-		}
-
-		ip, ok := ipv4["value"].(string)
-		if !ok || ip == "" {
-			continue
-		}
-
-		clusters = append(clusters, map[string]string{
-			"name": name,
-			"ip":   ip,
-		})
-	}
-
-	// Adjust total count to exclude unnamed clusters
-	return clusters, totalCount - unnamedCount, nil
 }
 
 func (es *ExporterService) setupHTTPHandlers() {

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -18,6 +18,7 @@ limitations under the License.
 package exporter
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -59,9 +60,10 @@ func NewExporterService(cfg *Config, credProvider CredentialProvider) *ExporterS
 }
 
 // StartWithServer initializes the exporter. When startHTTPServer is true, the
-// built-in HTTP server is also started on the default listen address.
-func (es *ExporterService) StartWithServer(startHTTPServer bool) error {
-	return es.svc.StartWithServer(startHTTPServer)
+// built-in HTTP server is also started on the default listen address. The
+// provided context controls the lifecycle of background refresh goroutines.
+func (es *ExporterService) StartWithServer(ctx context.Context, startHTTPServer bool) error {
+	return es.svc.StartWithServer(ctx, startHTTPServer)
 }
 
 // GetHandler returns an http.Handler that serves combined Prometheus metrics


### PR DESCRIPTION
# Refactoring internal modules for readability and testability

## Description

Changes by package:

**internal/nutanix**
- Combined PE and PC clients into single client struct with NutanixClient interface
- Improved credential fetching: Previously on cache miss, credentials were fetched once per collector (5x in <1 second). Now goroutines share a RWMutex to only fetch from the first collector.
- Moved in fetchClusters logic from service package, taking nutanixClient directly
- renamed cluster fetch and parse methods and improved error handling around unexpected API response shapes
- Moved prometheus registry from here to service layer

**internal/collector**
- renamed internal/prom to internal/collector
- Added shared Exporter base struct with apiPath and a single collect method drastically reducing boilerplate
- Moved normalizeKey and valueToFloat64 from methods on exporter to package level functions
- Split initMetrics and add initMetricsFromFile so initMetrics does not depend on a filesystem (for future testing)
- inlined fetchData helper into Collect method (only callsite)
- Removed empty wrappers for the various exporters
- unexported labels and metrics

**internal/service**
- Moved cluster fetching logic from here to nutanix package
- Moved prometheus registry here from nutanix package (no prom dependency in http layer)
- Threaded context through start, refreshClusters, and fetchClusters for better cancellation/timeout propagation
- Added default HTTP timeouts for read, write, idle

**internal/auth**
- Moved regex compilation out of convertClusterName to top of package to only compile once rather than on every lookup
- Removed double json round trip in getCreds - now asserts from vault returned map[string]any directly

## Types of Changes

What types of changes does your code introduce? Keep the ones that apply:

- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements

## Deployment Notes

No functional or breaking changes.
