### PR TITLE
Make listen address configurable via EXPORTER_LISTEN_ADDRESS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Example exporter.env:
 PC_CLUSTER_NAME='Prism Central' (Required, can be any value, letters a-z,A-Z, numbers 0-9, underscores (_), space ( ) and dash (-))
 PC_CLUSTER_URL=https://your-pc-cluster.yourdomain.com:9440 (Required, the full URL to Prism Central)
 PC_API_VERSION=v3 (Optional, defaults to v4. Supports v3, v4b1, v4)
+EXPORTER_LISTEN_ADDRESS=:9408 (Optional, defaults to :9408. Address and port the exporter listens on)
 CLUSTER_REFRESH_INTERVAL=1800 (Optional, defaults to 30 minutes, value is in seconds)
 CLUSTER_PREFIX=optional-cluster-prefix (Optional, prefix to filter cluster names)
 CONFIG_PATH=/etc/prometheus-nutanix-exporter/ (Optional, defaults to `./configs`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	PETaskAccount          string        `env:"PE_TASK_ACCOUNT"`
 	PCTaskAccount          string        `env:"PC_TASK_ACCOUNT"`
 	ConfigPath             string        `env:"CONFIG_PATH" envDefault:"./configs"`
+	ListenAddress          string        `env:"EXPORTER_LISTEN_ADDRESS" envDefault:":9408"`
 }
 
 func NewConfig() (*Config, error) {

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -32,8 +32,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const ListenAddress = ":9408"
-
 // clusterEntry pairs a Nutanix cluster with its dedicated Prometheus registry.
 // Keeping the registry here rather than on nutanix.Cluster means the HTTP client
 // layer has no Prometheus dependency.
@@ -83,7 +81,7 @@ func (es *ExporterService) StartWithServer(ctx context.Context, startHTTPServer 
 
 		// Start server
 		go func() {
-			slog.Info("Starting server", "address", ListenAddress)
+			slog.Info("Starting server", "address", es.config.ListenAddress)
 			if err := es.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				slog.Error("Server error", "error", err)
 			}
@@ -251,7 +249,7 @@ func (es *ExporterService) setupHTTPHandlers() {
 	mux.HandleFunc("/metrics/", es.metricsHandler)
 
 	es.server = &http.Server{
-		Addr:         ListenAddress,
+		Addr:         es.config.ListenAddress,
 		Handler:      mux,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,

--- a/internal/service/exporter_test.go
+++ b/internal/service/exporter_test.go
@@ -97,8 +97,8 @@ func Test_setupHTTPHandlers(t *testing.T) {
 	if es.server == nil {
 		t.Fatal("setupHTTPHandlers() left server nil")
 	}
-	if es.server.Addr != ListenAddress {
-		t.Errorf("server.Addr = %q, want %q", es.server.Addr, ListenAddress)
+	if es.server.Addr != es.config.ListenAddress {
+		t.Errorf("server.Addr = %q, want %q", es.server.Addr, es.config.ListenAddress)
 	}
 	if es.server.ReadTimeout != 10*time.Second {
 		t.Errorf("server.ReadTimeout = %v, want 10s", es.server.ReadTimeout)


### PR DESCRIPTION
# One-line summary

Make listen address configurable via EXPORTER_LISTEN_ADDRESS env var

## Description

You may need to change the port and IP address where the metric is published—for example, localhost:9108—if you do not want to export the service to the entire network.

## Types of Changes

- New feature (non-breaking change which adds functionality)

