### PR TITLE
Add opt-in skip of the Prism Central appliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The Nutanix Exporter is a Go application that fetches live data from any number 
 - Parent Exporter class that can be extended for any APIv2 endpoint
 - Per cluster metrics exposed at `/metrics/cluster-name`
 - Optional filtering by cluster name prefix
+- Optional exclusion of the Prism Central appliance from the discovered cluster list
 - TLS encryption and HTTP basic authentication via [exporter-toolkit web configuration](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md)
 
 ## Getting Started
@@ -39,6 +40,19 @@ The Nutanix Exporter is a Go application that fetches live data from any number 
     - `PE_PASSWORD_CLUSTER_NAME`
 
     **Note:** consecutive non-alphanumeric characters are collapsed into a single underscore. For example, `cluster--name` and `cluster-name` both map to `PE_USERNAME_CLUSTER_NAME`.
+
+### Cluster Discovery
+
+The exporter discovers clusters by querying Prism Central, then scrapes each one through the Prism Element APIs. Prism Central lists its own appliance alongside the Prism Element clusters it manages, and that entry is included by default.
+
+The PC appliance does not serve the Prism Element v1/v2 APIs the collectors depend on, so it cannot produce metrics. If you do not hold credentials for it, every discovery cycle logs a credential failure for it:
+
+```text
+level=ERROR msg="Failed to get credentials" kind="Prism Element" name=ProdCentral-NXP000
+level=WARN msg="Failed to initialize cluster" name=ProdCentral-NXP000
+```
+
+Set `SKIP_PC_APPLIANCE=true` to exclude it. The appliance is identified by the cluster function Prism Central reports for it (`clusterFunction` on v4, `service_list` on v3), not by name. The default is `false` to preserve existing behaviour; if a response omits that field the cluster is kept rather than dropped.
 
 ### Metrics Configuration
 
@@ -103,6 +117,7 @@ PC_API_VERSION=v3 (Optional, defaults to v4. Supports v3, v4b1, v4)
 EXPORTER_LISTEN_ADDRESS=:9408 (Optional, defaults to :9408. Address and port the exporter listens on)
 CLUSTER_REFRESH_INTERVAL=1800 (Optional, defaults to 30 minutes, value is in seconds)
 CLUSTER_PREFIX=optional-cluster-prefix (Optional, prefix to filter cluster names)
+SKIP_PC_APPLIANCE=true (Optional, defaults to false. Excludes the Prism Central appliance from the discovered cluster list)
 CONFIG_PATH=/etc/prometheus-nutanix-exporter/ (Optional, defaults to `./configs`)
 
 ### For HashiCorp Vault only

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	PrismCentralName       string        `env:"PC_CLUSTER_NAME,required"`
 	ClusterRefreshInterval time.Duration `env:"CLUSTER_REFRESH_INTERVAL" envDefault:"30m"`
 	ClusterPrefix          string        `env:"CLUSTER_PREFIX" envDefault:""`
+	SkipPCAppliance        bool          `env:"SKIP_PC_APPLIANCE" envDefault:"false"`
 	PCAPIVersion           string        `env:"PC_API_VERSION" envDefault:"v4"`
 	VaultAddress           string        `env:"VAULT_ADDR"`
 	VaultRoleId            string        `env:"VAULT_ROLE_ID"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,6 +76,48 @@ func Test_NewConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("SkipPCAppliance defaults to false when unset", func(t *testing.T) {
+		t.Setenv("PC_CLUSTER_URL", "https://10.0.0.1:9440")
+		t.Setenv("PC_CLUSTER_NAME", "my-pc")
+		unsetenv(t, "SKIP_PC_APPLIANCE")
+
+		cfg, err := NewConfig()
+		if err != nil {
+			t.Fatalf("NewConfig() unexpected error: %v", err)
+		}
+		if cfg.SkipPCAppliance {
+			t.Error("SkipPCAppliance = true, want false so existing deployments keep scraping the PC appliance")
+		}
+	})
+
+	t.Run("SkipPCAppliance is opt in", func(t *testing.T) {
+		tests := []struct {
+			value string
+			want  bool
+		}{
+			{value: "true", want: true},
+			{value: "1", want: true},
+			{value: "false", want: false},
+			{value: "0", want: false},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.value, func(t *testing.T) {
+				t.Setenv("PC_CLUSTER_URL", "https://10.0.0.1:9440")
+				t.Setenv("PC_CLUSTER_NAME", "my-pc")
+				t.Setenv("SKIP_PC_APPLIANCE", tt.value)
+
+				cfg, err := NewConfig()
+				if err != nil {
+					t.Fatalf("NewConfig() unexpected error: %v", err)
+				}
+				if cfg.SkipPCAppliance != tt.want {
+					t.Errorf("SKIP_PC_APPLIANCE=%q gave SkipPCAppliance = %v, want %v", tt.value, cfg.SkipPCAppliance, tt.want)
+				}
+			})
+		}
+	})
+
 	t.Run("missing required var returns error", func(t *testing.T) {
 		unsetenv(t, "PC_CLUSTER_URL")
 		unsetenv(t, "PC_CLUSTER_NAME")

--- a/internal/nutanix/clusters.go
+++ b/internal/nutanix/clusters.go
@@ -65,17 +65,40 @@ func NewCluster(name, rawURL string, ncp auth.CredentialProvider, isPC bool, ski
 	}
 }
 
+// prismCentralFunction is the cluster function reported by Prism Central for its
+// own appliance, in both the v3 service_list and the v4 clusterFunction fields.
+const prismCentralFunction = "PRISM_CENTRAL"
+
+// clusterInfo is a single cluster entry parsed from a Prism Central API response.
+type clusterInfo struct {
+	name string
+	ip   string
+	// isPC reports whether this entry is the Prism Central appliance itself
+	// rather than a Prism Element cluster.
+	isPC bool
+}
+
+// FetchOptions controls which clusters FetchClusters returns.
+type FetchOptions struct {
+	// APIVersion selects the PC API variant ("v3", "v4b1", or "v4" / anything else).
+	APIVersion string
+	// Prefix, when non-empty, filters out clusters whose names don't start with it.
+	Prefix string
+	// SkipPCAppliance, when true, filters out the Prism Central appliance itself.
+	// PC exposes only v3/v4 APIs, not the PE v1/v2 APIs the collectors use, so it
+	// cannot be scraped by this exporter.
+	SkipPCAppliance bool
+}
+
 // FetchClusters queries Prism Central via client and returns a map of cluster name -> URL.
-// apiVersion selects the PC API variant ("v3", "v4b1", or "v4" / anything else).
-// prefix, when non-empty, filters clusters whose names don't start with it.
-func FetchClusters(ctx context.Context, client NutanixClient, apiVersion, prefix string) (map[string]string, error) {
+func FetchClusters(ctx context.Context, client NutanixClient, opts FetchOptions) (map[string]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
 	var makeRequest func(context.Context, int) (*http.Response, error)
-	var parseClusters func(map[string]any) ([]map[string]string, int, error)
+	var parseClusters func(map[string]any) ([]clusterInfo, int, error)
 
-	switch apiVersion {
+	switch opts.APIVersion {
 	case "v3":
 		makeRequest = func(ctx context.Context, page int) (*http.Response, error) {
 			return fetchClustersV3(ctx, client, page)
@@ -98,7 +121,7 @@ func FetchClusters(ctx context.Context, client NutanixClient, apiVersion, prefix
 	totalExpected := 0
 	totalFetched := 0
 
-	slog.Info("Fetching clusters", "api_version", apiVersion)
+	slog.Info("Fetching clusters", "api_version", opts.APIVersion, "skip_pc_appliance", opts.SkipPCAppliance)
 
 	for {
 		slog.Info("Fetching clusters page", "page", page)
@@ -134,11 +157,16 @@ func FetchClusters(ctx context.Context, client NutanixClient, apiVersion, prefix
 		pageClusterCount := 0
 		duplicateCount := 0
 		for _, cluster := range clusters {
-			name := cluster["name"]
-			ip := cluster["ip"]
+			name := cluster.name
+			ip := cluster.ip
 
-			if prefix != "" && !strings.HasPrefix(name, prefix) {
-				slog.Info("Skipping cluster due to prefix filter", "name", name, "prefix", prefix)
+			if opts.SkipPCAppliance && cluster.isPC {
+				slog.Info("Skipping Prism Central appliance", "name", name)
+				continue
+			}
+
+			if opts.Prefix != "" && !strings.HasPrefix(name, opts.Prefix) {
+				slog.Info("Skipping cluster due to prefix filter", "name", name, "prefix", opts.Prefix)
 				continue
 			}
 
@@ -220,7 +248,24 @@ func fetchClustersV4b1(ctx context.Context, client NutanixClient, page int) (*ht
 	})
 }
 
-func parseClustersV3(result map[string]any) ([]map[string]string, int, error) {
+// hasPrismCentralFunction reports whether a cluster function list marks the entry
+// as the Prism Central appliance. A missing or malformed list reads as false so an
+// unexpected response shape leaves the cluster in place rather than silently
+// dropping it.
+func hasPrismCentralFunction(functions any) bool {
+	list, ok := functions.([]any)
+	if !ok {
+		return false
+	}
+	for _, fn := range list {
+		if s, ok := fn.(string); ok && strings.EqualFold(s, prismCentralFunction) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseClustersV3(result map[string]any) ([]clusterInfo, int, error) {
 	entities, ok := result["entities"].([]any)
 	if !ok {
 		return nil, 0, fmt.Errorf("unexpected v3 response format: missing 'entities' field")
@@ -236,7 +281,7 @@ func parseClustersV3(result map[string]any) ([]map[string]string, int, error) {
 	}
 	totalCount := int(totalMatches)
 
-	var clusters []map[string]string
+	var clusters []clusterInfo
 	unnamedCount := 0
 	for _, entity := range entities {
 		cluster, ok := entity.(map[string]any)
@@ -271,16 +316,23 @@ func parseClustersV3(result map[string]any) ([]map[string]string, int, error) {
 			continue
 		}
 
-		clusters = append(clusters, map[string]string{
-			"name": name,
-			"ip":   ip,
+		// v3 reports cluster functions under status.resources.config.service_list.
+		isPC := false
+		if config, ok := resources["config"].(map[string]any); ok {
+			isPC = hasPrismCentralFunction(config["service_list"])
+		}
+
+		clusters = append(clusters, clusterInfo{
+			name: name,
+			ip:   ip,
+			isPC: isPC,
 		})
 	}
 
 	return clusters, totalCount - unnamedCount, nil
 }
 
-func parseClustersV4(result map[string]any) ([]map[string]string, int, error) {
+func parseClustersV4(result map[string]any) ([]clusterInfo, int, error) {
 	data, ok := result["data"].([]any)
 	if !ok {
 		return nil, 0, fmt.Errorf("unexpected v4 response format: missing 'data' field")
@@ -296,7 +348,7 @@ func parseClustersV4(result map[string]any) ([]map[string]string, int, error) {
 	}
 	totalCount := int(totalAvailable)
 
-	var clusters []map[string]string
+	var clusters []clusterInfo
 	unnamedCount := 0
 	for _, item := range data {
 		clusterMap, ok := item.(map[string]any)
@@ -330,9 +382,16 @@ func parseClustersV4(result map[string]any) ([]map[string]string, int, error) {
 			continue
 		}
 
-		clusters = append(clusters, map[string]string{
-			"name": name,
-			"ip":   ip,
+		// v4 reports cluster functions under config.clusterFunction.
+		isPC := false
+		if config, ok := clusterMap["config"].(map[string]any); ok {
+			isPC = hasPrismCentralFunction(config["clusterFunction"])
+		}
+
+		clusters = append(clusters, clusterInfo{
+			name: name,
+			ip:   ip,
+			isPC: isPC,
 		})
 	}
 

--- a/internal/nutanix/clusters_test.go
+++ b/internal/nutanix/clusters_test.go
@@ -1,0 +1,285 @@
+/*
+Copyright © 2024-2026 Ingka Holding B.V. All Rights Reserved.
+Licensed under the GPL, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       <https://www.gnu.org/licenses/gpl-3.0.en.html>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nutanix
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// mockClient serves a fixed JSON body for every request, which is enough for
+// FetchClusters: a page holding fewer than 100 clusters ends pagination.
+type mockClient struct {
+	body string
+}
+
+func (m *mockClient) MakeRequest(_ context.Context, _, _ string, _ ...RequestOptions) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(m.body)),
+	}, nil
+}
+
+const (
+	pcApplianceName = "ProdCentral-NXP000"
+	peClusterName   = "ProdSite1-NXC000"
+)
+
+// The PC appliance and one PE cluster, shaped as Prism Central reports them.
+const (
+	clustersV4Body = `{
+		"metadata": {"totalAvailableResults": 2},
+		"data": [
+			{
+				"name": "ProdCentral-NXP000",
+				"network": {"externalAddress": {"ipv4": {"value": "10.0.0.1"}}},
+				"config": {"clusterFunction": ["PRISM_CENTRAL"]}
+			},
+			{
+				"name": "ProdSite1-NXC000",
+				"network": {"externalAddress": {"ipv4": {"value": "10.0.0.2"}}},
+				"config": {"clusterFunction": ["AOS"]}
+			}
+		]
+	}`
+
+	clustersV3Body = `{
+		"metadata": {"total_matches": 2},
+		"entities": [
+			{
+				"spec": {"name": "ProdCentral-NXP000"},
+				"status": {"resources": {
+					"network": {"external_ip": "10.0.0.1"},
+					"config": {"service_list": ["PRISM_CENTRAL"]}
+				}}
+			},
+			{
+				"spec": {"name": "ProdSite1-NXC000"},
+				"status": {"resources": {
+					"network": {"external_ip": "10.0.0.2"},
+					"config": {"service_list": ["AOS"]}
+				}}
+			}
+		]
+	}`
+)
+
+func decodeBody(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var result map[string]any
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		t.Fatalf("test fixture is not valid JSON: %v", err)
+	}
+	return result
+}
+
+func Test_hasPrismCentralFunction(t *testing.T) {
+	tests := []struct {
+		name      string
+		functions any
+		want      bool
+	}{
+		{name: "PRISM_CENTRAL present", functions: []any{"PRISM_CENTRAL"}, want: true},
+		{name: "PRISM_CENTRAL alongside others", functions: []any{"AOS", "PRISM_CENTRAL"}, want: true},
+		{name: "case insensitive", functions: []any{"prism_central"}, want: true},
+		{name: "AOS only", functions: []any{"AOS"}, want: false},
+		{name: "empty list", functions: []any{}, want: false},
+		{name: "missing field", functions: nil, want: false},
+		{name: "not a list", functions: "PRISM_CENTRAL", want: false},
+		{name: "non-string entries ignored", functions: []any{42, true}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasPrismCentralFunction(tt.functions); got != tt.want {
+				t.Errorf("hasPrismCentralFunction(%v) = %v, want %v", tt.functions, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseClustersV4_DetectsPrismCentral(t *testing.T) {
+	clusters, total, err := parseClustersV4(decodeBody(t, clustersV4Body))
+	if err != nil {
+		t.Fatalf("parseClustersV4() unexpected error: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("total = %d, want 2", total)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("parsed %d clusters, want 2", len(clusters))
+	}
+	if !clusters[0].isPC {
+		t.Errorf("%q isPC = false, want true", clusters[0].name)
+	}
+	if clusters[1].isPC {
+		t.Errorf("%q isPC = true, want false", clusters[1].name)
+	}
+}
+
+func Test_parseClustersV4_MissingConfigIsNotPC(t *testing.T) {
+	body := `{
+		"metadata": {"totalAvailableResults": 1},
+		"data": [{
+			"name": "no-config",
+			"network": {"externalAddress": {"ipv4": {"value": "10.0.0.1"}}}
+		}]
+	}`
+
+	clusters, _, err := parseClustersV4(decodeBody(t, body))
+	if err != nil {
+		t.Fatalf("parseClustersV4() unexpected error: %v", err)
+	}
+	if len(clusters) != 1 {
+		t.Fatalf("parsed %d clusters, want 1", len(clusters))
+	}
+	if clusters[0].isPC {
+		t.Error("cluster with no config field marked as PC, want it kept as PE")
+	}
+}
+
+func Test_parseClustersV3_DetectsPrismCentral(t *testing.T) {
+	clusters, total, err := parseClustersV3(decodeBody(t, clustersV3Body))
+	if err != nil {
+		t.Fatalf("parseClustersV3() unexpected error: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("total = %d, want 2", total)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("parsed %d clusters, want 2", len(clusters))
+	}
+	if !clusters[0].isPC {
+		t.Errorf("%q isPC = false, want true", clusters[0].name)
+	}
+	if clusters[1].isPC {
+		t.Errorf("%q isPC = true, want false", clusters[1].name)
+	}
+}
+
+func Test_parseClustersV3_MissingConfigIsNotPC(t *testing.T) {
+	body := `{
+		"metadata": {"total_matches": 1},
+		"entities": [{
+			"spec": {"name": "no-config"},
+			"status": {"resources": {"network": {"external_ip": "10.0.0.1"}}}
+		}]
+	}`
+
+	clusters, _, err := parseClustersV3(decodeBody(t, body))
+	if err != nil {
+		t.Fatalf("parseClustersV3() unexpected error: %v", err)
+	}
+	if len(clusters) != 1 {
+		t.Fatalf("parsed %d clusters, want 1", len(clusters))
+	}
+	if clusters[0].isPC {
+		t.Error("cluster with no config field marked as PC, want it kept as PE")
+	}
+}
+
+func Test_FetchClusters_SkipPCAppliance(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		body       string
+	}{
+		{name: "v4", apiVersion: "v4", body: clustersV4Body},
+		{name: "v4b1", apiVersion: "v4b1", body: clustersV4Body},
+		{name: "v3", apiVersion: "v3", body: clustersV3Body},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"/included by default", func(t *testing.T) {
+			client := &mockClient{body: tt.body}
+			got, err := FetchClusters(context.Background(), client, FetchOptions{APIVersion: tt.apiVersion})
+			if err != nil {
+				t.Fatalf("FetchClusters() unexpected error: %v", err)
+			}
+
+			want := map[string]string{
+				pcApplianceName: "https://10.0.0.1:9440",
+				peClusterName:   "https://10.0.0.2:9440",
+			}
+			if len(got) != len(want) {
+				t.Fatalf("got %d clusters, want %d: %v", len(got), len(want), got)
+			}
+			for name, url := range want {
+				if got[name] != url {
+					t.Errorf("cluster %q = %q, want %q", name, got[name], url)
+				}
+			}
+		})
+
+		t.Run(tt.name+"/excluded when skipping", func(t *testing.T) {
+			client := &mockClient{body: tt.body}
+			got, err := FetchClusters(context.Background(), client, FetchOptions{
+				APIVersion:      tt.apiVersion,
+				SkipPCAppliance: true,
+			})
+			if err != nil {
+				t.Fatalf("FetchClusters() unexpected error: %v", err)
+			}
+
+			if _, exists := got[pcApplianceName]; exists {
+				t.Errorf("PC appliance %q present, want it skipped", pcApplianceName)
+			}
+			if got[peClusterName] != "https://10.0.0.2:9440" {
+				t.Errorf("PE cluster %q = %q, want it retained", peClusterName, got[peClusterName])
+			}
+			if len(got) != 1 {
+				t.Errorf("got %d clusters, want 1: %v", len(got), got)
+			}
+		})
+	}
+}
+
+func Test_FetchClusters_SkipPCApplianceWithPrefix(t *testing.T) {
+	client := &mockClient{body: clustersV4Body}
+	got, err := FetchClusters(context.Background(), client, FetchOptions{
+		APIVersion:      "v4",
+		Prefix:          "Prod",
+		SkipPCAppliance: true,
+	})
+	if err != nil {
+		t.Fatalf("FetchClusters() unexpected error: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d clusters, want 1: %v", len(got), got)
+	}
+	if _, exists := got[peClusterName]; !exists {
+		t.Errorf("expected %q to survive both filters, got %v", peClusterName, got)
+	}
+}
+
+func Test_FetchClusters_PrefixExcludesEverything(t *testing.T) {
+	client := &mockClient{body: clustersV4Body}
+	got, err := FetchClusters(context.Background(), client, FetchOptions{
+		APIVersion: "v4",
+		Prefix:     "OTHER",
+	})
+	if err != nil {
+		t.Fatalf("FetchClusters() unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d clusters, want 0: %v", len(got), got)
+	}
+}

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -172,7 +172,11 @@ func (es *ExporterService) startRefreshRoutines(ctx context.Context) {
 }
 
 func (es *ExporterService) refreshClusters(ctx context.Context) error {
-	clusterData, err := nutanix.FetchClusters(ctx, es.pcCluster.API, es.config.PCAPIVersion, es.config.ClusterPrefix)
+	clusterData, err := nutanix.FetchClusters(ctx, es.pcCluster.API, nutanix.FetchOptions{
+		APIVersion:      es.config.PCAPIVersion,
+		Prefix:          es.config.ClusterPrefix,
+		SkipPCAppliance: es.config.SkipPCAppliance,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to fetch clusters: %w", err)
 	}

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -34,8 +34,12 @@ type Config struct {
 	PrismCentralName       string
 	ClusterRefreshInterval time.Duration
 	ClusterPrefix          string
-	PCAPIVersion           string
-	ConfigPath             string
+	// SkipPCAppliance excludes the Prism Central appliance from the discovered
+	// cluster list. PC does not serve the Prism Element v1/v2 APIs the collectors
+	// use, so it cannot be scraped by this exporter.
+	SkipPCAppliance bool
+	PCAPIVersion    string
+	ConfigPath      string
 }
 
 // CredentialProvider defines the interface for Nutanix credential management.
@@ -54,6 +58,7 @@ func NewExporterService(cfg *Config, credProvider CredentialProvider) *ExporterS
 		PrismCentralName:       cfg.PrismCentralName,
 		ClusterRefreshInterval: cfg.ClusterRefreshInterval,
 		ClusterPrefix:          cfg.ClusterPrefix,
+		SkipPCAppliance:        cfg.SkipPCAppliance,
 		PCAPIVersion:           cfg.PCAPIVersion,
 		ConfigPath:             cfg.ConfigPath,
 	}


### PR DESCRIPTION
# Add opt-in skip of the Prism Central appliance

## Description

Prism Central lists its own appliance alongside the Prism Element clusters it manages. The appliance does not serve the PE v1/v2 APIs the collectors use, so it cannot produce metrics.

Add SKIP_PC_APPLIANCE (default false) to exclude it. The appliance is identified by the cluster function Prism Central reports rather than by name: config.clusterFunction on v4/v4b1, status.resources.config.service_list on v3. Detection fails open, so a response missing that field leaves the cluster in place rather than silently dropping it.

The parsers now return a typed clusterInfo instead of map[string]string so PC-ness reaches the filter, and FetchClusters takes a FetchOptions struct rather than growing to five positional parameters.

Verified against live Prism Central on v3, v4b1 and v4.

## Types of Changes

What types of changes does your code introduce? Keep the ones that apply:

- New feature (non-breaking change which adds functionality)
- Configuration change
- Refactor/improvements
- Documentation / non-code

## Deployment Notes

New optional SKIP_PC_APPLIANCE env var, defaults to false to preserve existing behavior