### PR TITLE
Implement Prometheus HTTP service discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Nutanix Exporter is a Go application that fetches live data from any number 
 - Support for reading cluster credentials from environment variables
 - Parent Exporter class that can be extended for any APIv2 endpoint
 - Per cluster metrics exposed at `/metrics/cluster-name`
+- Prometheus HTTP service discovery at `/sd`, removing the need for a hand-maintained cluster list
 - Optional filtering by cluster name prefix
 - Optional exclusion of the Prism Central appliance from the discovered cluster list
 - TLS encryption and HTTP basic authentication via [exporter-toolkit web configuration](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md)
@@ -53,6 +54,57 @@ level=WARN msg="Failed to initialize cluster" name=ProdCentral-NXP000
 ```
 
 Set `SKIP_PC_APPLIANCE=true` to exclude it. The appliance is identified by the cluster function Prism Central reports for it (`clusterFunction` on v4, `service_list` on v3), not by name. The default is `false` to preserve existing behaviour; if a response omits that field the cluster is kept rather than dropped.
+
+### Prometheus Service Discovery
+
+Because the cluster list is discovered at runtime, Prometheus should not have to maintain its own copy of it. The exporter serves the clusters it knows about at `/sd` in [http_sd](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config) format, which replaces one hand-written scrape job per cluster with a single job:
+
+```yaml
+  - job_name: "nutanix"
+    http_sd_configs:
+      - url: "http://nutanix-exporter:9408/sd"
+        refresh_interval: 5m
+```
+
+Every cluster is served from the same exporter address and distinguished by the `__metrics_path__` label, which points at that cluster's `/metrics/<cluster-name>` endpoint. Prometheus keys targets on the full label set, so targets sharing an address remain distinct. A response looks like:
+
+```json
+[
+  {
+    "targets": ["nutanix-exporter:9408"],
+    "labels": {
+      "__metrics_path__": "/metrics/ProdSite1-NXC000",
+      "__meta_nutanix_cluster": "ProdSite1-NXC000",
+      "instance": "ProdSite1-NXC000"
+    }
+  }
+]
+```
+
+`instance` is set explicitly. Left to default, Prometheus derives it from the target address, and since every cluster shares one address they would all collide on a single instance value, making `up` and `scrape_duration_seconds` impossible to attribute to a cluster. Relabel from `__meta_nutanix_cluster` if you want a different value.
+
+A full example, including the client settings needed when the exporter is behind TLS or basic auth, is in [examples/sample_prometheus.yaml](./examples/sample_prometheus.yaml).
+
+#### Target address
+
+By default each target is advertised using the `Host` of the discovery request. Set `EXPORTER_SD_TARGET` when the scrape address should differ from the discovery address, for example behind a proxy that terminates on a different hostname.
+
+#### Refresh intervals
+
+`refresh_interval` controls only how often Prometheus re-reads `/sd`. The list behind it is refreshed by the exporter on `CLUSTER_REFRESH_INTERVAL` (default 30 minutes), so a shorter `refresh_interval` re-reads the same data and a newly added cluster will not appear until the exporter's own refresh runs. Keep `refresh_interval` at or above `CLUSTER_REFRESH_INTERVAL` unless you have a reason to poll more often.
+
+#### Cluster names in paths
+
+Cluster names are URL-escaped when building `__metrics_path__`, so names containing spaces or other characters that are not URL-safe still resolve correctly. Names remain easiest to work with when limited to letters, numbers, dots, dashes and underscores, since they also appear in the `cluster_name` metric label and in the `PE_USERNAME_<CLUSTERNAME>` environment variables described above.
+
+#### Scraping every cluster in one request
+
+The `pkg/exporter` package also exposes `GetHandler()`, which merges every cluster's registry into a single combined scrape. It is convenient when embedding the exporter with a small number of clusters, but it does not scale:
+
+- All clusters are collected in one request, so one slow or unreachable cluster delays the response and can push it past the server's write timeout, costing every other cluster its data point.
+- A single scrape carries a single `up` value, so a failure cannot be attributed to a cluster.
+
+Per-cluster scraping through service discovery avoids both: Prometheus scrapes the clusters in parallel as independent targets, and a broken cluster fails only its own target. Embedders that want this behaviour without running the built-in HTTP server can mount `GetMetricsHandler()` on `/metrics/` and `GetServiceDiscoveryHandler()` on `/sd`.
 
 ### Metrics Configuration
 
@@ -115,6 +167,7 @@ PC_CLUSTER_NAME='Prism Central' (Required, can be any value, letters a-z,A-Z, nu
 PC_CLUSTER_URL=https://your-pc-cluster.yourdomain.com:9440 (Required, the full URL to Prism Central)
 PC_API_VERSION=v3 (Optional, defaults to v4. Supports v3, v4b1, v4)
 EXPORTER_LISTEN_ADDRESS=:9408 (Optional, defaults to :9408. Address and port the exporter listens on)
+EXPORTER_SD_TARGET=nutanix-exporter:9408 (Optional. Address advertised to Prometheus by /sd, defaults to the Host of the discovery request)
 CLUSTER_REFRESH_INTERVAL=1800 (Optional, defaults to 30 minutes, value is in seconds)
 CLUSTER_PREFIX=optional-cluster-prefix (Optional, prefix to filter cluster names)
 SKIP_PC_APPLIANCE=true (Optional, defaults to false. Excludes the Prism Central appliance from the discovered cluster list)

--- a/examples/sample_prometheus.yaml
+++ b/examples/sample_prometheus.yaml
@@ -10,16 +10,42 @@ scrape_configs:
     static_configs:
       - targets: ["grafana:3000"]
 
-# One job per cluster
+# One job for every Nutanix cluster.
+#
+# The exporter serves the clusters it discovered from Prism Central at /sd, in
+# Prometheus http_sd format. Each entry carries a __metrics_path__ label, so all
+# targets share the exporter's address and differ only by path. Prometheus keys
+# targets on the full label set, so these stay distinct.
+#
+# refresh_interval only controls how often Prometheus re-reads /sd. The list
+# itself is refreshed by the exporter on CLUSTER_REFRESH_INTERVAL (default 30m),
+# so a shorter value here just re-reads the same data.
 
-  - job_name: "nutanix_exporter[$CLUSTER_NAME]"
-    metrics_path: "/metrics/$CLUSTER_NAME"
-    static_configs:
-      - targets: ["NutanixExporter:9408"]
+  - job_name: "nutanix"
+    http_sd_configs:
+      - url: "http://NutanixExporter:9408/sd"
+        refresh_interval: 5m
 
-# PC also gets its own "cluster"
+# The exporter already sets the instance label to the cluster name. Relabel from
+# __meta_nutanix_cluster instead if you want a different value, for example to
+# add an environment prefix:
+#
+#   relabel_configs:
+#     - source_labels: [__meta_nutanix_cluster]
+#       target_label: instance
+#       replacement: "prod/$1"
 
-  - job_name: "nutanix_exporter[$PC_CLUSTER_NAME]"
-    metrics_path: "/metrics/$PC_CLUSTER_NAME"
-    static_configs:
-      - targets: ["NutanixExporter:9408"]
+# When the exporter is served over TLS or behind basic auth (see
+# --web.config.file), the discovery request needs matching client settings:
+#
+#   - job_name: "nutanix"
+#     http_sd_configs:
+#       - url: "https://NutanixExporter:9408/sd"
+#         refresh_interval: 5m
+#         basic_auth:
+#           username: prometheus
+#           password: <password>
+#     scheme: https
+#     basic_auth:
+#       username: prometheus
+#       password: <password>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	PCTaskAccount          string        `env:"PC_TASK_ACCOUNT"`
 	ConfigPath             string        `env:"CONFIG_PATH" envDefault:"./configs"`
 	ListenAddress          string        `env:"EXPORTER_LISTEN_ADDRESS" envDefault:":9408"`
+	SDTargetAddress        string        `env:"EXPORTER_SD_TARGET" envDefault:""`
 }
 
 func NewConfig() (*Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -118,6 +118,34 @@ func Test_NewConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("SDTargetAddress defaults to empty so the request Host is used", func(t *testing.T) {
+		t.Setenv("PC_CLUSTER_URL", "https://10.0.0.1:9440")
+		t.Setenv("PC_CLUSTER_NAME", "my-pc")
+		unsetenv(t, "EXPORTER_SD_TARGET")
+
+		cfg, err := NewConfig()
+		if err != nil {
+			t.Fatalf("NewConfig() unexpected error: %v", err)
+		}
+		if cfg.SDTargetAddress != "" {
+			t.Errorf("SDTargetAddress = %q, want empty", cfg.SDTargetAddress)
+		}
+	})
+
+	t.Run("SDTargetAddress is read from the environment", func(t *testing.T) {
+		t.Setenv("PC_CLUSTER_URL", "https://10.0.0.1:9440")
+		t.Setenv("PC_CLUSTER_NAME", "my-pc")
+		t.Setenv("EXPORTER_SD_TARGET", "nutanix-exporter:9408")
+
+		cfg, err := NewConfig()
+		if err != nil {
+			t.Fatalf("NewConfig() unexpected error: %v", err)
+		}
+		if cfg.SDTargetAddress != "nutanix-exporter:9408" {
+			t.Errorf("SDTargetAddress = %q, want %q", cfg.SDTargetAddress, "nutanix-exporter:9408")
+		}
+	})
+
 	t.Run("missing required var returns error", func(t *testing.T) {
 		unsetenv(t, "PC_CLUSTER_URL")
 		unsetenv(t, "PC_CLUSTER_NAME")

--- a/internal/service/discovery.go
+++ b/internal/service/discovery.go
@@ -1,0 +1,108 @@
+/*
+Copyright © 2024-2026 Ingka Holding B.V. All Rights Reserved.
+Licensed under the GPL, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       <https://www.gnu.org/licenses/gpl-3.0.en.html>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sort"
+)
+
+const (
+	// metricsPathLabel tells Prometheus which path to scrape a target on. Every
+	// cluster shares one exporter address and is distinguished only by this path.
+	metricsPathLabel = "__metrics_path__"
+
+	// clusterMetaLabel exposes the cluster name for use in relabel_configs. The
+	// "__meta_" prefix follows the convention for service discovery metadata:
+	// Prometheus drops it after relabeling unless it is explicitly kept.
+	clusterMetaLabel = "__meta_nutanix_cluster"
+
+	// instanceLabel is set explicitly because every target here resolves to the
+	// same address. Left to default, Prometheus would derive instance from
+	// __address__ and every cluster would collide on one instance value.
+	instanceLabel = "instance"
+)
+
+// sdTargetGroup is a single entry in a Prometheus http_sd_config response.
+// See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config
+type sdTargetGroup struct {
+	Targets []string          `json:"targets"`
+	Labels  map[string]string `json:"labels"`
+}
+
+// serviceDiscoveryHandler serves the discovered clusters as Prometheus http_sd
+// target groups, replacing a hand-maintained list of per-cluster scrape jobs.
+//
+// The list is only as fresh as the last cluster refresh, so setting a Prometheus
+// refresh_interval shorter than CLUSTER_REFRESH_INTERVAL re-reads the same data.
+func (es *ExporterService) serviceDiscoveryHandler(w http.ResponseWriter, r *http.Request) {
+	groups := es.discoveryTargets(es.sdTargetAddress(r))
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(groups); err != nil {
+		// The status line is already sent, so this can only be logged.
+		slog.Error("Failed to encode service discovery response", "error", err)
+	}
+}
+
+// sdTargetAddress returns the address Prometheus should scrape. It defaults to
+// the Host of the discovery request itself. EXPORTER_SD_TARGET overrides it for deployments
+// where the scrape address differs from the discovery address.
+func (es *ExporterService) sdTargetAddress(r *http.Request) string {
+	if es.config.SDTargetAddress != "" {
+		return es.config.SDTargetAddress
+	}
+	return r.Host
+}
+
+// discoveryTargets builds one target group per known cluster, sorted by cluster
+// name so the response is stable between requests.
+func (es *ExporterService) discoveryTargets(address string) []sdTargetGroup {
+	es.clustersMu.RLock()
+	names := make([]string, 0, len(es.clustersMap))
+	for name := range es.clustersMap {
+		names = append(names, name)
+	}
+	es.clustersMu.RUnlock()
+
+	sort.Strings(names)
+
+	// Built empty rather than nil so an exporter with no clusters encodes as []
+	// instead of null, which Prometheus rejects.
+	groups := make([]sdTargetGroup, 0, len(names))
+	for _, name := range names {
+		groups = append(groups, sdTargetGroup{
+			Targets: []string{address},
+			Labels: map[string]string{
+				metricsPathLabel: metricsPathFor(name),
+				clusterMetaLabel: name,
+				instanceLabel:    name,
+			},
+		})
+	}
+
+	return groups
+}
+
+// metricsPathFor returns the scrape path for a cluster. The name is escaped so
+// that characters which are not URL-safe survive the round trip back to
+// metricsHandler, which looks the cluster up by the decoded path.
+func metricsPathFor(name string) string {
+	return "/metrics/" + url.PathEscape(name)
+}

--- a/internal/service/discovery_test.go
+++ b/internal/service/discovery_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright © 2024-2026 Ingka Holding B.V. All Rights Reserved.
+Licensed under the GPL, Version 3 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       <https://www.gnu.org/licenses/gpl-3.0.en.html>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ingka-group/nutanix-exporter/internal/nutanix"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// addCluster registers a cluster with an empty registry so it appears in
+// discovery output and is servable by metricsHandler.
+func addCluster(es *ExporterService, name string) {
+	es.clustersMap[name] = &clusterEntry{
+		cluster:  &nutanix.Cluster{Name: name},
+		registry: prometheus.NewRegistry(),
+	}
+}
+
+// requestDiscovery calls the handler and decodes the response.
+func requestDiscovery(t *testing.T, es *ExporterService, host string) ([]sdTargetGroup, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/sd", nil)
+	if host != "" {
+		req.Host = host
+	}
+	w := httptest.NewRecorder()
+	es.serviceDiscoveryHandler(w, req)
+
+	var groups []sdTargetGroup
+	if err := json.Unmarshal(w.Body.Bytes(), &groups); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, w.Body.String())
+	}
+	return groups, w
+}
+
+func Test_serviceDiscoveryHandler_ContentType(t *testing.T) {
+	es := newTestService()
+	addCluster(es, "cluster-a")
+
+	_, w := requestDiscovery(t, es, "exporter:9408")
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	// Prometheus rejects the response unless this is exactly application/json.
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+}
+
+func Test_serviceDiscoveryHandler_EmptyIsEmptyArray(t *testing.T) {
+	es := newTestService()
+
+	req := httptest.NewRequest(http.MethodGet, "/sd", nil)
+	w := httptest.NewRecorder()
+	es.serviceDiscoveryHandler(w, req)
+
+	// Encoding a nil slice would yield "null", which Prometheus rejects.
+	if got := w.Body.String(); got != "[]\n" {
+		t.Errorf("body with no clusters = %q, want %q", got, "[]\n")
+	}
+}
+
+func Test_serviceDiscoveryHandler_TargetsAndLabels(t *testing.T) {
+	es := newTestService()
+	addCluster(es, "ProdSite1-NXC000")
+
+	groups, _ := requestDiscovery(t, es, "exporter:9408")
+
+	if len(groups) != 1 {
+		t.Fatalf("got %d target groups, want 1", len(groups))
+	}
+	g := groups[0]
+
+	if len(g.Targets) != 1 || g.Targets[0] != "exporter:9408" {
+		t.Errorf("targets = %v, want [exporter:9408]", g.Targets)
+	}
+	if got := g.Labels[metricsPathLabel]; got != "/metrics/ProdSite1-NXC000" {
+		t.Errorf("%s = %q, want %q", metricsPathLabel, got, "/metrics/ProdSite1-NXC000")
+	}
+	if got := g.Labels[clusterMetaLabel]; got != "ProdSite1-NXC000" {
+		t.Errorf("%s = %q, want %q", clusterMetaLabel, got, "ProdSite1-NXC000")
+	}
+	// Without this every cluster would inherit the same instance from __address__.
+	if got := g.Labels[instanceLabel]; got != "ProdSite1-NXC000" {
+		t.Errorf("%s = %q, want %q", instanceLabel, got, "ProdSite1-NXC000")
+	}
+}
+
+func Test_serviceDiscoveryHandler_UsesRequestHostByDefault(t *testing.T) {
+	es := newTestService()
+	addCluster(es, "cluster-a")
+
+	groups, _ := requestDiscovery(t, es, "nutanix-exporter.monitoring.svc:9408")
+
+	if len(groups) != 1 {
+		t.Fatalf("got %d target groups, want 1", len(groups))
+	}
+	if got := groups[0].Targets[0]; got != "nutanix-exporter.monitoring.svc:9408" {
+		t.Errorf("target = %q, want the request Host", got)
+	}
+}
+
+func Test_serviceDiscoveryHandler_SDTargetAddressOverridesHost(t *testing.T) {
+	es := newTestService()
+	es.config.SDTargetAddress = "public-exporter.example.com:443"
+	addCluster(es, "cluster-a")
+
+	groups, _ := requestDiscovery(t, es, "internal-host:9408")
+
+	if got := groups[0].Targets[0]; got != "public-exporter.example.com:443" {
+		t.Errorf("target = %q, want the configured override", got)
+	}
+}
+
+func Test_serviceDiscoveryHandler_SortedByClusterName(t *testing.T) {
+	es := newTestService()
+	// Inserted out of order; map iteration order is random.
+	for _, name := range []string{"cluster-c", "cluster-a", "cluster-b"} {
+		addCluster(es, name)
+	}
+
+	groups, _ := requestDiscovery(t, es, "exporter:9408")
+
+	if len(groups) != 3 {
+		t.Fatalf("got %d target groups, want 3", len(groups))
+	}
+	want := []string{"cluster-a", "cluster-b", "cluster-c"}
+	for i, name := range want {
+		if got := groups[i].Labels[clusterMetaLabel]; got != name {
+			t.Errorf("group %d cluster = %q, want %q", i, got, name)
+		}
+	}
+}
+
+func Test_metricsPathFor_EscapesUnsafeNames(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "cluster-a", want: "/metrics/cluster-a"},
+		{name: "cluster.name", want: "/metrics/cluster.name"},
+		{name: "cluster name", want: "/metrics/cluster%20name"},
+		{name: "cluster?x=1", want: "/metrics/cluster%3Fx=1"},
+		{name: "cluster#frag", want: "/metrics/cluster%23frag"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := metricsPathFor(tt.name); got != tt.want {
+				t.Errorf("metricsPathFor(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// The advertised path is only useful if it actually resolves back to the right
+// cluster, so drive the discovered path through the real mux.
+func Test_DiscoveredPathsResolveToTheirCluster(t *testing.T) {
+	names := []string{
+		"cluster-a",
+		"cluster.with.dots",
+		"cluster name with spaces",
+		"cluster?x=1",
+	}
+
+	es := newTestService()
+	for _, name := range names {
+		addCluster(es, name)
+	}
+	es.setupHTTPHandlers()
+
+	groups, _ := requestDiscovery(t, es, "exporter:9408")
+	if len(groups) != len(names) {
+		t.Fatalf("got %d target groups, want %d", len(groups), len(names))
+	}
+
+	for _, g := range groups {
+		path := g.Labels[metricsPathLabel]
+		cluster := g.Labels[clusterMetaLabel]
+
+		t.Run(cluster, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			es.server.Handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("GET %q for cluster %q = %d, want 200", path, cluster, w.Code)
+			}
+		})
+	}
+}
+
+func Test_DiscoveredPathForUnknownClusterIs404(t *testing.T) {
+	es := newTestService()
+	addCluster(es, "cluster-a")
+	es.setupHTTPHandlers()
+
+	req := httptest.NewRequest(http.MethodGet, metricsPathFor("cluster-b"), nil)
+	w := httptest.NewRecorder()
+	es.server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("unknown cluster path = %d, want 404", w.Code)
+	}
+}
+
+func Test_setupHTTPHandlers_ServesDiscoveryRoute(t *testing.T) {
+	es := newTestService()
+	addCluster(es, "cluster-a")
+	es.setupHTTPHandlers()
+
+	req := httptest.NewRequest(http.MethodGet, "/sd", nil)
+	w := httptest.NewRecorder()
+	es.server.Handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /sd = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}
+
+func Test_GetServiceDiscoveryHandler(t *testing.T) {
+	es := newTestService()
+	addCluster(es, "cluster-a")
+
+	req := httptest.NewRequest(http.MethodGet, "/sd", nil)
+	w := httptest.NewRecorder()
+	es.GetServiceDiscoveryHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GetServiceDiscoveryHandler = %d, want 200", w.Code)
+	}
+
+	var groups []sdTargetGroup
+	if err := json.Unmarshal(w.Body.Bytes(), &groups); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Errorf("got %d target groups, want 1", len(groups))
+	}
+}
+
+func Test_GetMetricsHandler(t *testing.T) {
+	es := newTestService()
+	addCluster(es, "cluster-a")
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics/cluster-a", nil)
+	w := httptest.NewRecorder()
+	es.GetMetricsHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GetMetricsHandler = %d, want 200", w.Code)
+	}
+}

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -86,6 +86,8 @@ func (es *ExporterService) StartWithServer(ctx context.Context, webFlags *web.Fl
 	return nil
 }
 
+// GetHandler returns a handler serving every cluster's metrics in one combined
+// scrape. See README on cluster discovery for preferred per-cluster scraping on large deployments.
 func (es *ExporterService) GetHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		es.clustersMu.RLock()
@@ -96,6 +98,18 @@ func (es *ExporterService) GetHandler() http.Handler {
 		es.clustersMu.RUnlock()
 		promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{}).ServeHTTP(w, r)
 	})
+}
+
+// GetMetricsHandler returns a handler serving a single cluster's metrics, chosen
+// by the path segment after "/metrics/". It must be mounted on that prefix.
+func (es *ExporterService) GetMetricsHandler() http.Handler {
+	return http.HandlerFunc(es.metricsHandler)
+}
+
+// GetServiceDiscoveryHandler returns a handler serving the discovered clusters
+// as Prometheus http_sd target groups, one target per cluster.
+func (es *ExporterService) GetServiceDiscoveryHandler() http.Handler {
+	return http.HandlerFunc(es.serviceDiscoveryHandler)
 }
 
 func (es *ExporterService) Stop() error {
@@ -246,6 +260,7 @@ func (es *ExporterService) setupHTTPHandlers() {
 
 	mux.HandleFunc("/", es.indexHandler)
 	mux.HandleFunc("/metrics/", es.metricsHandler)
+	mux.HandleFunc("/sd", es.serviceDiscoveryHandler)
 
 	es.server = &http.Server{
 		Handler:      mux,
@@ -256,7 +271,7 @@ func (es *ExporterService) setupHTTPHandlers() {
 }
 
 func (es *ExporterService) indexHandler(w http.ResponseWriter, r *http.Request) {
-	_, _ = fmt.Fprint(w, `<html><head><title>Nutanix Exporter</title></head><body><h1>Nutanix Exporter</h1><p><a href="/metrics">Metrics</a></p></body></html>`)
+	_, _ = fmt.Fprint(w, `<html><head><title>Nutanix Exporter</title></head><body><h1>Nutanix Exporter</h1><p><a href="/metrics">Metrics</a></p><p><a href="/sd">Service Discovery</a></p></body></html>`)
 }
 
 func (es *ExporterService) metricsHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -34,12 +34,10 @@ type Config struct {
 	PrismCentralName       string
 	ClusterRefreshInterval time.Duration
 	ClusterPrefix          string
-	// SkipPCAppliance excludes the Prism Central appliance from the discovered
-	// cluster list. PC does not serve the Prism Element v1/v2 APIs the collectors
-	// use, so it cannot be scraped by this exporter.
-	SkipPCAppliance bool
-	PCAPIVersion    string
-	ConfigPath      string
+	SkipPCAppliance        bool
+	PCAPIVersion           string
+	ConfigPath             string
+	SDTargetAddress        string
 }
 
 // CredentialProvider defines the interface for Nutanix credential management.
@@ -61,6 +59,7 @@ func NewExporterService(cfg *Config, credProvider CredentialProvider) *ExporterS
 		SkipPCAppliance:        cfg.SkipPCAppliance,
 		PCAPIVersion:           cfg.PCAPIVersion,
 		ConfigPath:             cfg.ConfigPath,
+		SDTargetAddress:        cfg.SDTargetAddress,
 	}
 	return &ExporterService{svc: service.NewExporterService(internalCfg, credProvider)}
 }
@@ -73,9 +72,24 @@ func (es *ExporterService) StartWithServer(ctx context.Context, webFlags *web.Fl
 }
 
 // GetHandler returns an http.Handler that serves combined Prometheus metrics
-// from all discovered Nutanix clusters.
+// from all discovered Nutanix clusters. See the README on cluster discovery for
+// why per-cluster scraping is preferred at fleet scale.
 func (es *ExporterService) GetHandler() http.Handler {
 	return es.svc.GetHandler()
+}
+
+// GetMetricsHandler returns an http.Handler serving a single cluster's metrics,
+// chosen by the path segment after "/metrics/". It must be mounted on that
+// prefix, and pairs with GetServiceDiscoveryHandler to give Prometheus one
+// target per cluster.
+func (es *ExporterService) GetMetricsHandler() http.Handler {
+	return es.svc.GetMetricsHandler()
+}
+
+// GetServiceDiscoveryHandler returns an http.Handler serving the discovered
+// clusters as Prometheus http_sd target groups, for use with http_sd_config.
+func (es *ExporterService) GetServiceDiscoveryHandler() http.Handler {
+	return es.svc.GetServiceDiscoveryHandler()
 }
 
 // Stop shuts down the exporter service gracefully.

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -57,6 +57,37 @@ func Test_Stop_noServer(t *testing.T) {
 	}
 }
 
+func Test_GetServiceDiscoveryHandler_respondsWithJSON(t *testing.T) {
+	es := newTestExporterService()
+
+	req := httptest.NewRequest(http.MethodGet, "/sd", nil)
+	w := httptest.NewRecorder()
+	es.GetServiceDiscoveryHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GetServiceDiscoveryHandler response = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+	// No clusters discovered, so an empty array rather than null.
+	if got := w.Body.String(); got != "[]\n" {
+		t.Errorf("body = %q, want %q", got, "[]\n")
+	}
+}
+
+func Test_GetMetricsHandler_unknownClusterIs404(t *testing.T) {
+	es := newTestExporterService()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics/nonexistent", nil)
+	w := httptest.NewRecorder()
+	es.GetMetricsHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GetMetricsHandler unknown cluster = %d, want 404", w.Code)
+	}
+}
+
 func Test_GetHandler_returnsHandler(t *testing.T) {
 	es := newTestExporterService()
 	h := es.GetHandler()


### PR DESCRIPTION
# Implement Prometheus HTTP service discovery

## Description

Adds a /sd route for providing scrapable clusters in prometheus format

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Configuration change
- Documentation / non-code

## Deployment Notes

Added optional SDTargetAddress env var for override