### PR TITLE
(MINOR) Release service discovery and make untagged commits bump patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,11 @@ jobs:
         major_pattern: "(MAJOR)"
         minor_pattern: "(MINOR)"
         version_format: "${major}.${minor}.${patch}"
+        # Every commit bumps at least the patch version. Without this, a merge
+        # commit carrying no (MAJOR)/(MINOR)/(PATCH) tag produces no bump at
+        # all, and the release re-publishes over the previous version and moves
+        # the 'latest' Docker tag onto it.
         bump_each_commit: true
-        bump_each_commit_patch_pattern: "(PATCH)"
 
     - name: Set up Artifactory CLI
       uses: jfrog/setup-jfrog-cli@86dacb6974c66cc99e7651e1205f6581aaddba9a

--- a/internal/service/exporter.go
+++ b/internal/service/exporter.go
@@ -41,6 +41,9 @@ type clusterEntry struct {
 	registry *prometheus.Registry
 }
 
+// ExporterService owns the discovered clusters and the HTTP surface that serves
+// their metrics. clustersMap is replaced wholesale on refresh and guarded by
+// clustersMu, so readers always see a complete cluster list.
 type ExporterService struct {
 	config             *config.Config
 	credentialProvider auth.CredentialProvider
@@ -50,6 +53,8 @@ type ExporterService struct {
 	pcCluster          *nutanix.Cluster
 }
 
+// NewExporterService returns an ExporterService with no clusters. Clusters are
+// discovered from Prism Central when the service is started.
 func NewExporterService(cfg *config.Config, credProvider auth.CredentialProvider) *ExporterService {
 	return &ExporterService{
 		config:             cfg,
@@ -58,10 +63,15 @@ func NewExporterService(cfg *config.Config, credProvider auth.CredentialProvider
 	}
 }
 
+// Start initializes the exporter and serves it over the built-in HTTP server.
 func (es *ExporterService) Start(ctx context.Context, webFlags *web.FlagConfig) error {
 	return es.StartWithServer(ctx, webFlags)
 }
 
+// StartWithServer connects to Prism Central, performs the first cluster
+// discovery and starts the background refresh routines. When webFlags is
+// non-nil the built-in HTTP server is started; pass nil when embedding the
+// exporter behind another server.
 func (es *ExporterService) StartWithServer(ctx context.Context, webFlags *web.FlagConfig) error {
 	if err := es.initializePrismCentral(); err != nil {
 		return fmt.Errorf("failed to initialize Prism Central: %w", err)
@@ -112,6 +122,9 @@ func (es *ExporterService) GetServiceDiscoveryHandler() http.Handler {
 	return http.HandlerFunc(es.serviceDiscoveryHandler)
 }
 
+// Stop gracefully shuts down the built-in HTTP server, waiting up to five
+// seconds for in-flight scrapes to finish. It is a no-op when the server was
+// never started.
 func (es *ExporterService) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
PR #50 merged without a major/minor/patch tag in its commit message. bump_each_commit_patch_pattern causes a commit matching none of the three patterns bumps nothing, so the release recomputed the previous version and re-published over v1.12.0. The git
tag and GitHub release were unaffected.

Drop bump_each_commit_patch_pattern so every commit bumps at least the patch version. A forgotten tag now degrades to a harmless patch release instead of overwriting a version that has already shipped.

Carries minor so service discovery is released as v1.13.0. The doc comments are a deliberate no-op change:  fill in exported symbols that were missing the comments CONTRIBUTING requires.
